### PR TITLE
Fix dynamic library dependency config not being merged correctly

### DIFF
--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/Config.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/Config.kt
@@ -24,9 +24,9 @@ internal data class Config(
     @SerialName("kotlin_target_version") val kotlinTargetVersion: String? = null,
     @SerialName("disable_java_cleaner") val disableJavaCleaner: Boolean? = false,
     @SerialName("generate_serializable_types") val generateSerializableTypes: Boolean? = null,
-    @SerialName("jvm_dependent_dynamic_libraries") val jvmDependentDynamicLibraries: List<String>? = null,
-    @SerialName("android_dependent_dynamic_libraries") val androidDependentDynamicLibraries: List<String>? = null,
-    @SerialName("dependent_dynamic_libraries") val dependentDynamicLibraries: List<String>? = null,
+    @SerialName("jvm_dynamic_library_dependencies") val jvmDynamicLibraryDependencies: List<String>? = null,
+    @SerialName("android_dynamic_library_dependencies") val androidDynamicLibraryDependencies: List<String>? = null,
+    @SerialName("dynamic_library_dependencies") val dynamicLibraryDependencies: List<String>? = null,
 ) {
     @Serializable
     internal data class CustomType(

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/MergeUniffiConfigTask.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/MergeUniffiConfigTask.kt
@@ -46,11 +46,15 @@ abstract class MergeUniffiConfigTask : DefaultTask() {
 
     @get:Input
     @get:Optional
-    abstract val jvmDependentDynamicLibraries: ListProperty<String>
+    abstract val jvmDynamicLibraryDependencies: ListProperty<String>
 
     @get:Input
     @get:Optional
-    abstract val androidDependentDynamicLibraries: ListProperty<String>
+    abstract val androidDynamicLibraryDependencies: ListProperty<String>
+
+    @get:Input
+    @get:Optional
+    abstract val dynamicLibraryDependencies: ListProperty<String>
 
     @get:OutputFile
     abstract val outputConfig: RegularFileProperty
@@ -67,14 +71,18 @@ abstract class MergeUniffiConfigTask : DefaultTask() {
                 ?: kotlinVersion.orNull?.takeIf { it.isNotBlank() },
             generateSerializableTypes = originalConfig.generateSerializableTypes
                 ?: useKotlinXSerialization.orNull,
-            jvmDependentDynamicLibraries = mergeSet(
-                originalConfig.jvmDependentDynamicLibraries,
-                jvmDependentDynamicLibraries.orNull,
+            jvmDynamicLibraryDependencies = mergeSet(
+                originalConfig.jvmDynamicLibraryDependencies,
+                jvmDynamicLibraryDependencies.orNull,
             ),
-            androidDependentDynamicLibraries = mergeSet(
-                originalConfig.androidDependentDynamicLibraries,
-                androidDependentDynamicLibraries.orNull,
+            androidDynamicLibraryDependencies = mergeSet(
+                originalConfig.androidDynamicLibraryDependencies,
+                androidDynamicLibraryDependencies.orNull,
             ),
+            dynamicLibraryDependencies = mergeSet(
+                originalConfig.dynamicLibraryDependencies,
+                dynamicLibraryDependencies.orNull,
+            )
         )
         outputConfig.get().asFile.writeText(toml.encodeToString(result), Charsets.UTF_8)
     }


### PR DESCRIPTION
Fixes typos in property names and serial names in `gobley.gradle.uniffi.Config`.