### PR TITLE
Fix Activity names in example AndroidManifests

### DIFF
--- a/examples/app/src/androidMain/AndroidManifest.xml
+++ b/examples/app/src/androidMain/AndroidManifest.xml
@@ -4,7 +4,7 @@
             android:supportsRtl="true"
             android:theme="@android:style/Theme.Material.NoActionBar">
         <activity
-                android:name=".MainActivity"
+                android:name="gobley.uniffi.examples.app.MainActivity"
                 android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/examples/audio-cpp-app/src/androidMain/AndroidManifest.xml
+++ b/examples/audio-cpp-app/src/androidMain/AndroidManifest.xml
@@ -6,7 +6,7 @@
             android:supportsRtl="true"
             android:theme="@android:style/Theme.Material.NoActionBar">
         <activity
-                android:name=".MainActivity"
+                android:name="gobley.uniffi.examples.audiocppapp.MainActivity"
                 android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/examples/tokio-blake3-app/src/androidMain/AndroidManifest.xml
+++ b/examples/tokio-blake3-app/src/androidMain/AndroidManifest.xml
@@ -6,7 +6,7 @@
             android:supportsRtl="true"
             android:theme="@android:style/Theme.Material.NoActionBar">
         <activity
-                android:name=".MainActivity"
+                android:name="gobley.uniffi.examples.tokioblake3app.MainActivity"
                 android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
## Changes

Fixed Activity names in example projects' `AndroidManifest.xml` (e.g., `.MainActivity` -> `gobley.uniffi.examples.app.MainActivity`). This fixes `ClassNotFoundException` in runtime. This error was introduced by 10736932034b40439c20d3ddce27f1482b664716, which changed the package names from `dev.gobley.*` to `gobley.*`.