### PR TITLE
Fix the wrong UniFFI version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,4 +1045,4 @@ Here is how `gobley-uniffi-bindgen` versions are tied to `uniffi-rs` are tied:
 
 | gobley-uniffi-bindgen version | uniffi-rs version |
 |-------------------------------|-------------------|
-| v0.1.0                        | v0.25.2           |
+| v0.1.0                        | v0.28.3           |


### PR DESCRIPTION
Changed the UniFFI version mentioned in the documentation from 0.25.2 to 0.28.3.