### PR TITLE
Don't build the dependency image in PR checks

### DIFF
--- a/.github/workflows/dependency-image.yml
+++ b/.github/workflows/dependency-image.yml
@@ -9,6 +9,12 @@ on:
       build-image:
         description: "The name of the Docker image"
         value: ${{ jobs.build-image.outputs.build-image }}
+      build-image-name:
+        description: "The name of the Docker image without the hash"
+        value: ${{ jobs.build-image.outputs.build-image-name }}
+      build-image-hash:
+        description: "The hash or the tag of the Docker image"
+        value: ${{ jobs.build-image.outputs.build-image-hash }}
 
 jobs:
   build-image:
@@ -17,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-image: ${{ steps.build-image.outputs.build-image }}
+      build-image-name: ${{ steps.build-image.outputs.build-image-name }}
+      build-image-hash: ${{ steps.build-image.outputs.build-image-hash }}
     steps:
       - uses: actions/checkout@v4
       - name: Enable Docker CLI experimental features
@@ -41,5 +49,7 @@ jobs:
             fi
           fi
           echo "build-image=$BUILD_IMAGE" >> $GITHUB_OUTPUT
+          echo "build-image-name=$BUILD_IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "build-image-hash=$BUILD_IMAGE_HASH" >> $GITHUB_OUTPUT
         env:
           BUILD_IMAGE_TRIGGER_EVENT: ${{ inputs.trigger-event }}

--- a/.github/workflows/dependency-image.yml
+++ b/.github/workflows/dependency-image.yml
@@ -2,6 +2,9 @@ name: Build Docker image containing required dependencies
 
 on:
   workflow_call:
+    inputs:
+      trigger-event:
+        type: string
     outputs:
       build-image:
         description: "The name of the Docker image"
@@ -24,9 +27,19 @@ jobs:
         id: build-image
         run: |
           BUILD_IMAGE_HASH=$(echo -n "$(cat Cargo.lock .github/workflows/dependency-image.Dockerfile gradle/libs.versions.toml)" | md5sum | cut -c1-8)
-          BUILD_IMAGE="ghcr.io/${{ github.repository }}/dependency-image:$BUILD_IMAGE_HASH"
-          echo "build-image=$BUILD_IMAGE" >> $GITHUB_OUTPUT
+          BUILD_IMAGE_NAME="ghcr.io/${{ github.repository }}/dependency-image"
+          BUILD_IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_HASH"
           if ! docker manifest inspect $BUILD_IMAGE; then
-            docker build -t $BUILD_IMAGE -f ./.github/workflows/dependency-image.Dockerfile .
-            docker push $BUILD_IMAGE
+            if [ "$BUILD_IMAGE_TRIGGER_EVENT" = "pull_request" ]; then
+              BUILD_IMAGE_HASH="pr-latest"
+              BUILD_IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_HASH"
+            else
+              docker build -t $BUILD_IMAGE -f ./.github/workflows/dependency-image.Dockerfile .
+              docker push $BUILD_IMAGE
+              docker tag $BUILD_IMAGE $BUILD_IMAGE_NAME:pr-latest
+              docker push $BUILD_IMAGE_NAME:pr-latest
+            fi
           fi
+          echo "build-image=$BUILD_IMAGE" >> $GITHUB_OUTPUT
+        env:
+          BUILD_IMAGE_TRIGGER_EVENT: ${{ inputs.trigger-event }}

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -11,6 +11,8 @@ jobs:
     name: Build Docker image containing required dependencies
     uses: ./.github/workflows/dependency-image.yml
     secrets: inherit
+    with:
+      trigger-event: ${{ github.event_name }}
   build-and-test:
     name: Build and run unit tests
     timeout-minutes: 120

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Docker login to GitHub Container Registry
         run: docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+      - name: Build without pushing the image if not present
+        if: ${{ needs.build-image.outputs.build-image-hash == 'pr-latest' }}
+        run: |
+          docker build -t $BUILD_IMAGE -f ./.github/workflows/dependency-image.Dockerfile .
+        env:
+          BUILD_IMAGE: ${{ needs.build-image.outputs.build-image }}
       - name: Run tests in container
         run: |
           docker run --rm \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     name: Build Docker image containing required dependencies
     uses: ./.github/workflows/dependency-image.yml
     secrets: inherit
+    with:
+      trigger-event: ${{ github.event_name }}
   publish:
     name: Publish Gobley to Maven Central and crates.io
     timeout-minutes: 120


### PR DESCRIPTION
## Changes

GitHub doesn't allow workflows to have the write packages permissions when they are triggered by the pull_request event. An error happens when the PR check workflow tries to push a new dependency image.

This PR makes `dependency-image.yml` don't push the new image in PRs. When a new image is needed, it will return the `:pr-latest` tag instead. When `:pr-latest` is returned, `pr-build-test.yml` will build but not push the image. This prevents the permission error.

When the PR is merged, `dependency-image.yml` will push the new image.