### PR TITLE
Fix JUnit test report commit

### DIFF
--- a/.github/workflows/pr-build-test-report.yml
+++ b/.github/workflows/pr-build-test-report.yml
@@ -32,4 +32,5 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         with:
           check_name: 'JUnit test report (${{ matrix.test-name }})'
+          commit: ${{ github.event.workflow_run.head_sha }}
           report_paths: '**/test-results/*est/TEST-*.xml'


### PR DESCRIPTION
Fixed `pr-build-test-report.yml` always reporting the test results to `main`.