### PR TITLE
Reflect #29, #32, and #35 to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,10 +676,14 @@ When the bindings are generated correctly, it has a directory structure like the
 │   └── headers
 │       └── <namespace name>
 │           └── <namespace name>.h
-└── nativeMain
+├── nativeMain
+│   └── kotlin
+│       └── <namespace name>
+│           └── <namespace name>.native.kt
+└── stubMain
     └── kotlin
         └── <namespace name>
-            └── <namespace name>.native.kt
+            └── <namespace name>.stub.kt
 ```
 
 ### Bindgen configuration

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ and `KotlinNativeCompilation.useRustUpLinker` and one extension property `Projec
 
 `hostNativeTarget` can be invoked in `kotlin {}` and adds the Kotlin Native target for the build host; it invokes
 `mingwX64` on Windows, `macosX64` or `macosArm64` on macOS, and `linuxX64` or `linuxArm64` on Linux, though Linux Arm64
-build host is not supported yet.
+build host is not supported by Kotlin/Native yet.
 
 ```kotlin
 import gobley.gradle.rust.dsl.*

--- a/README.md
+++ b/README.md
@@ -479,10 +479,11 @@ Some directories like the NDK installation directory or the Cargo build output d
 
 #### Enabling the nightly mode and building tier 3 Rust targets
 
-Some targets like tvOS and watchOS are tier 3 in the Rust world (they are tier 2 in the Kotlin side). Pre-built standard libraries are not available for these targets. To use the standard library, you
-must pass the `-Zbuild-std` flag to the `cargo build` command (See [here](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std)
-for the official documentation). Since this flag is available only on the nightly channel, you
-should configure the Cargo plugin to do so.
+Some targets like tvOS and watchOS are tier 3 in the Rust world (they are tier 2 on the Kotlin side). Pre-built standard
+libraries are not available for these targets. To use the standard library, you must pass the `-Zbuild-std` flag to the
+`cargo build` command (See [here](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) for the official
+documentation). Since this flag is available only on the nightly channel, you should tell the Cargo plugin to
+use the nightly compiler to compile the standard library.
 
 First, download the source code of the standard library using the following command.
 


### PR DESCRIPTION
## Changes

- Reflected #29 to the "The Bindgen" section in README.
- Rewrote the description about the lack of support for the AArch64 Linux build host (mentioned in #32) in README.
- Rewrote the "Enabling the nightly mode and building tier 3 Rust targets" section (introduced by #35) in README.