### PR TITLE
Prevent docs deployment from running in a forked repo

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     name: Deploy documentation
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.repository == 'gobley/gobley' && github.event_name != 'pull_request' }}
     needs: build
     permissions:
       contents: read


### PR DESCRIPTION
## Changes

A follow-up PR for #41. Documentation deployment runs in forked repos. This PR prevents it.

## Testing

Tested in a forked repo.

| Before fix | After fix |
| - | - |
| ![image](https://github.com/user-attachments/assets/634be5ed-9437-4867-8207-498ba1a4b501) | ![image](https://github.com/user-attachments/assets/ab61fe6a-6d06-4942-81de-9cecb6c6dafc) |