### PR TITLE
Ensure list and map elements are destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Kotlin JVM and Kotlin Android Gradle plugins
   support ([#44](https://github.com/gobley/gobley/pull/44) & [#47](https://github.com/gobley/gobley/pull/47)).
 
+### Fixes
+
+- Ensured interface instances in lists and maps are
+  destroyed ([#53](https://github.com/gobley/gobley/pull/53)).
+
 ## [0.1.0](https://github.com/gobley/gobley/releases/tag/v0.1.0) - 2025-03-03
 
 ### New Features

--- a/bindgen/src/templates/common/Types.kt
+++ b/bindgen/src/templates/common/Types.kt
@@ -16,8 +16,22 @@ interface Disposable : AutoCloseable {
     companion object {
         internal fun destroy(vararg args: Any?) {
             for (arg in args) {
-                if (arg is Disposable) {
-                    arg.destroy()
+                when (arg) {
+                    is Disposable -> arg.destroy()
+                    is List<*> -> {
+                        for (element in arg) {
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
+                    is Map<*, *> -> {
+                        for (element in arg.values) {
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/bindgen/src/templates/common/Types.kt
+++ b/bindgen/src/templates/common/Types.kt
@@ -18,7 +18,7 @@ interface Disposable : AutoCloseable {
             for (arg in args) {
                 when (arg) {
                     is Disposable -> arg.destroy()
-                    is List<*> -> {
+                    is Iterable<*> -> {
                         for (element in arg) {
                             if (element is Disposable) {
                                 element.destroy()
@@ -27,6 +27,13 @@ interface Disposable : AutoCloseable {
                     }
                     is Map<*, *> -> {
                         for (element in arg.values) {
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
+                    is Array<*> -> {
+                        for (element in arg) {
                             if (element is Disposable) {
                                 element.destroy()
                             }

--- a/tests/uniffi/coverall/src/commonMain/rust/lib.rs
+++ b/tests/uniffi/coverall/src/commonMain/rust/lib.rs
@@ -191,6 +191,8 @@ pub struct SimpleDict {
     float64: f64,
     maybe_float64: Option<f64>,
     coveralls: Option<Arc<Coveralls>>,
+    coveralls_list: Vec<Option<Arc<Coveralls>>>,
+    coveralls_map: HashMap<String, Option<Arc<Coveralls>>>,
     test_trait: Option<Arc<dyn NodeTrait>>,
 }
 
@@ -309,6 +311,24 @@ fn create_some_dict() -> SimpleDict {
         float64: 0.0,
         maybe_float64: Some(1.0),
         coveralls: Some(Arc::new(Coveralls::new("some_dict".to_string()))),
+        coveralls_list: vec![
+            Some(Arc::new(Coveralls::new("some_dict_1".to_string()))),
+            None,
+            Some(Arc::new(Coveralls::new("some_dict_2".to_string()))),
+        ],
+        coveralls_map: [
+            (
+                "some_dict_3".to_string(),
+                Some(Arc::new(Coveralls::new("some_dict_3".to_string()))),
+            ),
+            ("none".to_string(), None),
+            (
+                "some_dict_4".to_string(),
+                Some(Arc::new(Coveralls::new("some_dict_4".to_string()))),
+            ),
+        ]
+        .into_iter()
+        .collect(),
         test_trait: Some(Arc::new(traits::Trait2::default())),
     }
 }

--- a/tests/uniffi/coverall/src/commonTest/kotlin/CoverallTest.kt
+++ b/tests/uniffi/coverall/src/commonTest/kotlin/CoverallTest.kt
@@ -98,7 +98,7 @@ class CoverallTest {
     }
 
     @Test
-    fun dict() {
+    fun dict() = withCoverallLock {
         // floats should be "close enough".
         infix fun Float.almostEquals(other: Float) =
             shouldBe(FloatToleranceMatcher(other, 0.000001F))
@@ -132,7 +132,19 @@ class CoverallTest {
             d.maybeFloat64!! almostEquals 1.0
 
             d.coveralls!!.getName() shouldBe "some_dict"
+
+            d.coverallsList[0]!!.getName() shouldBe "some_dict_1"
+            d.coverallsList[1] shouldBe null
+            d.coverallsList[2]!!.getName() shouldBe "some_dict_2"
+
+            d.coverallsMap["some_dict_3"]!!.getName() shouldBe "some_dict_3"
+            d.coverallsMap["none"] shouldBe null
+            d.coverallsMap["some_dict_4"]!!.getName() shouldBe "some_dict_4"
+
+            getNumAlive() shouldBe 5UL
         }
+
+        getNumAlive() shouldBe 0UL
 
         createNoneDict().use { d ->
             d.text shouldBe "text"
@@ -158,7 +170,11 @@ class CoverallTest {
             d.maybeFloat64 shouldBe null
 
             d.coveralls shouldBe null
+
+            getNumAlive() shouldBe 0UL
         }
+
+        getNumAlive() shouldBe 0UL
     }
 
     @Test

--- a/tests/uniffi/coverall/src/coverall.udl
+++ b/tests/uniffi/coverall/src/coverall.udl
@@ -60,6 +60,8 @@ dictionary SimpleDict {
     double float64;
     double? maybe_float64;
     Coveralls? coveralls;
+    sequence<Coveralls?> coveralls_list;
+    record<string, Coveralls?> coveralls_map;
     NodeTrait? test_trait;
 };
 


### PR DESCRIPTION
## Changes

- Made `Disposable.destroy()` check whether the given argument is a `List<*>` or a `Map<*, *>` containing `Disposable`.

## Testing

- Modified `:tests:uniffi:coveralls`. Inside `SimpleDict`, added two properties `coveralls_list` and `coveralls_map`, which contain `Coveralls` in a `Vec` or `HashMap`, respectively.
- Checked whether interface instances are destroyed or not via `getNumAlives()` inside test `fun dict()`.

## Issues Fixed

Fixes: #45
