### PR TITLE
Add `CargoCheckTask`

### DIFF
--- a/.github/workflows/pr-build-test-examples.ps1
+++ b/.github/workflows/pr-build-test-examples.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew allTests `
+    ./gradlew check `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.uniffiTests=false";
 } finally {

--- a/.github/workflows/pr-build-test-gradle-tests.ps1
+++ b/.github/workflows/pr-build-test-gradle-tests.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew allTests `
+    ./gradlew check `
         "-Pgobley.projects.uniffiTests=false" `
         "-Pgobley.projects.examples=false";
 } finally {

--- a/.github/workflows/pr-build-test-uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test-uniffi-tests.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew allTests `
+    ./gradlew check `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.examples=false";
 } finally {

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -260,6 +260,9 @@ class CargoPlugin : Plugin<Project> {
                         additionalEnvironment.putAll(environmentVariables)
                     }
                 }
+                cargoBuildVariant.checkTaskProvider.configure {
+                    dependsOn(rustUpTargetAddTask)
+                }
             }
             for (kotlinTarget in cargoBuild.kotlinTargets) {
                 when (kotlinTarget) {
@@ -309,6 +312,7 @@ class CargoPlugin : Plugin<Project> {
         androidTarget: KotlinAndroidTarget?,
     ) {
         val buildTask = cargoBuildVariant.buildTaskProvider
+        val checkTask = cargoBuildVariant.checkTaskProvider
         val findDynamicLibrariesTask = cargoBuildVariant.findDynamicLibrariesTaskProvider
         cargoBuildVariant.dynamicLibrarySearchPaths.add(
             cargoBuildVariant.profile.zip(cargoExtension.cargoPackage) { profile, cargoPackage ->
@@ -359,6 +363,12 @@ class CargoPlugin : Plugin<Project> {
                 } else if (name.contains(kotlinTarget.name)) {
                     dependsOn(copyTask)
                 }
+            }
+        }
+
+        if (cargoBuildVariant.embedRustLibrary.get()) {
+            tasks.named("check") {
+                dependsOn(checkTask)
             }
         }
 
@@ -422,6 +432,7 @@ class CargoPlugin : Plugin<Project> {
         cargoBuildVariant: CargoAndroidBuildVariant,
     ) {
         val buildTask = cargoBuildVariant.buildTaskProvider
+        val checkTask = cargoBuildVariant.checkTaskProvider
         val findDynamicLibrariesTask = cargoBuildVariant.findDynamicLibrariesTaskProvider
         cargoBuildVariant.dynamicLibrarySearchPaths.add(
             cargoBuildVariant.profile.zip(cargoExtension.cargoPackage) { profile, cargoPackage ->
@@ -466,6 +477,10 @@ class CargoPlugin : Plugin<Project> {
         }
 
         androidDelegate.addMainJniDir(this, cargoBuildVariant.variant, copyTask, copyDestination)
+
+        tasks.named("check") {
+            dependsOn(checkTask)
+        }
     }
 
     private fun Project.configureNativeCompilation(
@@ -473,6 +488,7 @@ class CargoPlugin : Plugin<Project> {
         cargoBuildVariant: CargoNativeBuildVariant<*>,
     ) {
         val buildTask = cargoBuildVariant.buildTaskProvider
+        val checkTask = cargoBuildVariant.checkTaskProvider
 
         val buildOutputFile = buildTask
             .flatMap { it.libraryFileByCrateType }
@@ -495,6 +511,10 @@ class CargoPlugin : Plugin<Project> {
             compileTaskProvider.configure {
                 compilerOptions.optIn.add("kotlinx.cinterop.ExperimentalForeignApi")
             }
+        }
+
+        tasks.named("check") {
+            dependsOn(checkTask)
         }
     }
 

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuild.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuild.kt
@@ -9,6 +9,7 @@ package gobley.gradle.cargo.dsl
 import gobley.gradle.rust.targets.RustTarget
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.provider.Property
 import org.jetbrains.kotlin.gradle.plugin.HasProject
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
@@ -27,4 +28,9 @@ interface CargoBuild<out CargoBuildVariantT : CargoBuildVariant<RustTarget>>
      * The list of Kotlin targets requiring this Rust build.
      */
     val kotlinTargets: NamedDomainObjectCollection<KotlinTarget>
+
+    /**
+     * The Cargo command to use for linting. If you want to Clippy, set this to `clippy`.
+     */
+    val checkCommand: Property<String>
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuildVariant.kt
@@ -7,13 +7,15 @@
 package gobley.gradle.cargo.dsl
 
 import gobley.gradle.cargo.tasks.CargoBuildTask
+import gobley.gradle.cargo.tasks.CargoCheckTask
 import gobley.gradle.rust.targets.RustTarget
 import org.gradle.api.tasks.TaskProvider
 
 /**
  * Contains settings for a variant of a build.
  */
-interface CargoBuildVariant<out RustTargetT : RustTarget> : CargoVariant, HasRustTarget<RustTargetT> {
+interface CargoBuildVariant<out RustTargetT : RustTarget> : CargoVariant,
+    HasRustTarget<RustTargetT> {
     /**
      * The build containing this variant.
      */
@@ -29,4 +31,9 @@ interface CargoBuildVariant<out RustTargetT : RustTarget> : CargoVariant, HasRus
      * The build task of the current variant.
      */
     val buildTaskProvider: TaskProvider<CargoBuildTask>
+
+    /**
+     * The check task of the current variant.
+     */
+    val checkTaskProvider: TaskProvider<CargoCheckTask>
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoExtension.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoExtension.kt
@@ -17,12 +17,11 @@ import gobley.gradle.rust.targets.RustAppleMobileTarget
 import gobley.gradle.rust.targets.RustPosixTarget
 import gobley.gradle.rust.targets.RustTarget
 import gobley.gradle.rust.targets.RustWindowsTarget
-import gobley.gradle.utils.RustVersionUtils
-import io.github.z4kn4fein.semver.Version
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.plugins.DslObject
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.reflect.TypeOf
@@ -125,4 +124,10 @@ abstract class CargoExtension(final override val project: Project) : HasProject,
      */
     internal val nativeTargetVariantOverride: MapProperty<RustTarget, Variant> =
         project.objects.mapProperty()
+
+    /**
+     * The Cargo command to use for linting. If you want to Clippy, set this to `clippy`.
+     */
+    val checkCommand: Property<String> =
+        project.objects.property<String>().convention("check")
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuild.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuild.kt
@@ -46,5 +46,6 @@ abstract class DefaultCargoBuild<out RustTargetT : RustTarget, out CargoBuildVar
     init {
         @Suppress("LeakingThis")
         features.addAll(extension.features)
+        checkCommand.convention(extension.checkCommand)
     }
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuildVariant.kt
@@ -9,6 +9,7 @@ package gobley.gradle.cargo.dsl
 import gobley.gradle.Variant
 import gobley.gradle.cargo.CargoPlugin
 import gobley.gradle.cargo.tasks.CargoBuildTask
+import gobley.gradle.cargo.tasks.CargoCheckTask
 import gobley.gradle.cargo.utils.register
 import gobley.gradle.rust.targets.RustTarget
 import org.gradle.api.Project
@@ -31,11 +32,22 @@ abstract class DefaultCargoBuildVariant<out RustTargetT : RustTarget, out CargoB
     @Suppress("UNCHECKED_CAST")
     override val rustTarget: RustTargetT = build.rustTarget as RustTargetT
 
-    override val buildTaskProvider = project.tasks.register<CargoBuildTask>({ +this@DefaultCargoBuildVariant }) {
-        group = CargoPlugin.TASK_GROUP
-        cargoPackage.set(extension.cargoPackage)
-        profile.set(this@DefaultCargoBuildVariant.profile)
-        target.set(this@DefaultCargoBuildVariant.rustTarget)
-        features.set(this@DefaultCargoBuildVariant.features)
-    }
+    override val buildTaskProvider =
+        project.tasks.register<CargoBuildTask>({ +this@DefaultCargoBuildVariant }) {
+            group = CargoPlugin.TASK_GROUP
+            cargoPackage.set(extension.cargoPackage)
+            profile.set(this@DefaultCargoBuildVariant.profile)
+            target.set(this@DefaultCargoBuildVariant.rustTarget)
+            features.set(this@DefaultCargoBuildVariant.features)
+        }
+
+    override val checkTaskProvider =
+        project.tasks.register<CargoCheckTask>({ +this@DefaultCargoBuildVariant }) {
+            group = CargoPlugin.TASK_GROUP
+            cargoPackage.set(extension.cargoPackage)
+            profile.set(this@DefaultCargoBuildVariant.profile)
+            target.set(this@DefaultCargoBuildVariant.rustTarget)
+            features.set(this@DefaultCargoBuildVariant.features)
+            command.convention(extension.checkCommand)
+        }
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.cargo.tasks
+
+import gobley.gradle.InternalGobleyGradleApi
+import gobley.gradle.cargo.profiles.CargoProfile
+import gobley.gradle.rust.targets.RustTarget
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+@Suppress("LeakingThis")
+@CacheableTask
+abstract class CargoCheckTask : CargoPackageTask() {
+    @get:Input
+    abstract val profile: Property<CargoProfile>
+
+    @get:Input
+    abstract val target: Property<RustTarget>
+
+    @get:Input
+    abstract val features: SetProperty<String>
+
+    @get:Input
+    abstract val command: Property<String>
+
+    @TaskAction
+    @OptIn(InternalGobleyGradleApi::class)
+    fun build() {
+        val profile = profile.get()
+        val target = target.get()
+        cargo(command.get()) {
+            arguments("--profile", profile.profileName)
+            arguments("--target", target.rustTriple)
+            if (features.isPresent) {
+                if (features.get().isNotEmpty()) {
+                    arguments("--features", features.get().joinToString(","))
+                }
+            }
+            suppressXcodeIosToolchains()
+        }.get().apply {
+            assertNormalExitValue()
+        }
+    }
+}

--- a/tests/uniffi/coverall-jvm/build.gradle.kts
+++ b/tests/uniffi/coverall-jvm/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import gobley.gradle.GobleyHost
 import gobley.gradle.cargo.dsl.jvm
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -13,6 +14,13 @@ cargo {
     packageDirectory = project.layout.projectDirectory.dir("../coverall")
     builds.jvm {
         embedRustLibrary = rustTarget == GobleyHost.current.rustTarget
+    }
+    builds.configureEach {
+        variants {
+            buildTaskProvider.dependsOn(
+                project(":tests:uniffi:coverall").tasks.named(buildTaskProvider.name)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Changes

- Added `CargoCheckTask`.
- Added `CargoBuildVariant.checkTaskProvider`.
- Made the corresponding `CargoCheckTask` depend on the `check` task when `CargoBuildTask` is enabled.
- Fixed task dependency error in `:tests:uniffi:coverall-jvm` as it occurs when `./gradlew check` is invoked.
- Made CI test scripts use `./gradlew allTests` instead of `./gradlew clean`.

## Testing

Tested with `./gradlew check` in CI. When you run it in Android Studio/IntelliJ, you can see Cargo warnings in the Run menu.

![image](https://github.com/user-attachments/assets/27e1ccbd-d32d-4f9d-a86e-94148a7f3abd)

## Issues Fixed

Fixes: #49
