### PR TITLE
Allow using the UniFFI plugin without creating a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   support ([#44](https://github.com/gobley/gobley/pull/44) & [#47](https://github.com/gobley/gobley/pull/47)).
 - Config option for using PascalCase for enums ([#54](https://github.com/gobley/gobley/pull/54)).
 - `CargoCheckTask` for cross-platform linting ([#55](https://github.com/gobley/gobley/pull/55)).
+- `UniFfiPlugin` can be used without a UniFFI config
+  file ([#63](https://github.com/gobley/gobley/pull/63)).
 
 ### Fixes
 

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -178,7 +178,10 @@ class UniFfiPlugin : Plugin<Project> {
             originalConfig.set(
                 bindingsGeneration.config.orElse(
                     cargoExtension.packageDirectory.file("uniffi.toml"),
-                ),
+                ).map { regularFile ->
+                    // TODO: This compiles well, but Android Studio shows an error
+                    regularFile.takeIf { it.asFile.exists() }
+                }
             )
 
             @OptIn(InternalGobleyGradleApi::class)

--- a/tests/uniffi/docstring/src/commonTest/kotlin/DocstringTest.kt
+++ b/tests/uniffi/docstring/src/commonTest/kotlin/DocstringTest.kt
@@ -6,7 +6,7 @@
 
 @file:Suppress("unused", "UNUSED_VARIABLE")
 
-import docstring.*
+import uniffi.docstring.*
 import kotlin.test.Test
 
 class DocstringTest {

--- a/tests/uniffi/docstring/uniffi.toml
+++ b/tests/uniffi/docstring/uniffi.toml
@@ -1,1 +1,0 @@
-package_name = "docstring"


### PR DESCRIPTION
## Changes

Made the config file path passed to `MergeUniffiConfigFile` nullable when it doesn't exist.

## Testing

Removed the UniFFI config file from `:tests:uniffi:docstring`.

## Additional context

This is for smoother onboarding for newcomers.