### PR TITLE
Don't select the build for bindings generation excluded by embedRustLibrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Ensured interface instances in lists and maps are
   destroyed ([#53](https://github.com/gobley/gobley/pull/53)).
+- Prevented `UniFfiPlugin` from selecting a build excluded by
+  `embedRustLibrary` ([#64](https://github.com/gobley/gobley/pull/64)).
 
 ## [0.1.0](https://github.com/gobley/gobley/releases/tag/v0.1.0) - 2025-03-03
 


### PR DESCRIPTION
## Changes

Made the UniFFI plugin not select the build excluded by `embedRustLibrary`.

## Testing

Tested locally.

![image](https://github.com/user-attachments/assets/b95b8e73-2f01-4af0-906e-9c01fce23f21)

## Issues Fixed

Fixes: #60
