### PR TITLE
Fix NPE occurring when function returning RustArcPtr throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   destroyed ([#53](https://github.com/gobley/gobley/pull/53)).
 - Prevented `UniFfiPlugin` from selecting a build excluded by
   `embedRustLibrary` ([#64](https://github.com/gobley/gobley/pull/64)).
+- Prevented NPE occurring when functions returning RustArcPtr throw
+  errors ([#75](https://github.com/gobley/gobley/pull/75)).
 
 ## Dependencies
 

--- a/bindgen/src/templates/ffi/ObjectTemplate.kt
+++ b/bindgen/src/templates/ffi/ObjectTemplate.kt
@@ -125,8 +125,8 @@
 
     fun uniffiClonePointer(): Pointer {
         return uniffiRustCall { status ->
-            UniffiLib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)!!
-        }
+            UniffiLib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)
+        }!!
     }
 
     {% for meth in obj.methods() -%}

--- a/bindgen/src/templates/macros.kt
+++ b/bindgen/src/templates/macros.kt
@@ -35,16 +35,16 @@
                                 {%- endif -%}
                                 {%- call arg_list_lowered(func, indent + 8) %}
 {{ " "|repeat(indent) }}        uniffiRustCallStatus,
+{{ " "|repeat(indent) }}    )
                         {%- if let Some(return_type) = func.ffi_func().return_type() -%}
                         {%-     if return_type|need_non_null_assertion %}
-{{ " "|repeat(indent) }}    )!!
+{{ " "|repeat(indent) }}{{ '}' }}!!
                         {%-     else %}
-{{ " "|repeat(indent) }}    )
-                        {%- endif -%}
-                        {%- else %}
-{{ " "|repeat(indent) }}    )
-                        {%- endif %}
 {{ " "|repeat(indent) }}{{ '}' }}
+                        {%-     endif -%}
+                        {%- else %}
+{{ " "|repeat(indent) }}{{ '}' }}
+                        {%- endif %}
 {%- endmacro -%}
 
 {%- macro func_decl(func_decl, callable, indent, is_decl_override) %}

--- a/tests/uniffi/coverall/src/commonMain/rust/additional.rs
+++ b/tests/uniffi/coverall/src/commonMain/rust/additional.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+#[derive(uniffi::Object)]
+struct NotConstructible {}
+
+#[uniffi::export]
+impl NotConstructible {
+    #[uniffi::constructor]
+    fn new() -> Arc<Self> {
+        panic!("constructor panic")
+    }
+}
+
+#[uniffi::export]
+fn new_not_constructible() -> Arc<NotConstructible> {
+    panic!("function panic")
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+enum NotConstructibleError {
+    #[error("not constructible")]
+    NotConstructible,
+}
+
+#[derive(uniffi::Object)]
+struct NotConstructible2 {}
+
+#[uniffi::export]
+impl NotConstructible2 {
+    #[uniffi::constructor]
+    fn new() -> Result<Arc<Self>, NotConstructibleError> {
+        Err(NotConstructibleError::NotConstructible)
+    }
+}
+
+#[uniffi::export]
+fn new_not_constructible2() -> Result<Arc<NotConstructible2>, NotConstructibleError> {
+    Err(NotConstructibleError::NotConstructible)
+}

--- a/tests/uniffi/coverall/src/commonMain/rust/lib.rs
+++ b/tests/uniffi/coverall/src/commonMain/rust/lib.rs
@@ -9,6 +9,7 @@ use std::time::SystemTime;
 
 use once_cell::sync::Lazy;
 
+mod additional;
 mod traits;
 pub use traits::{
     ancestor_names, get_string_util_traits, get_traits, make_rust_getters, test_getters,

--- a/tests/uniffi/coverall/src/commonTest/kotlin/AdditionalCoverallTest.kt
+++ b/tests/uniffi/coverall/src/commonTest/kotlin/AdditionalCoverallTest.kt
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import coverall.InternalException
+import coverall.NotConstructible
+import coverall.NotConstructible2
+import coverall.NotConstructibleException
+import coverall.newNotConstructible
+import coverall.newNotConstructible2
+import io.kotest.assertions.throwables.shouldThrow
+import kotlin.test.Test
+
+// Covers test cases not in the original unit test in upstream.
+class AdditionalCoverallTest {
+    @Test
+    fun testPanicInsideFunctionReturningObject() {
+        shouldThrow<InternalException> {
+            NotConstructible()
+        }
+        shouldThrow<InternalException> {
+            newNotConstructible()
+        }
+    }
+
+    @Test
+    fun testErrorThrownFromFunctionReturningObject() {
+        shouldThrow<NotConstructibleException> {
+            NotConstructible2()
+        }
+        shouldThrow<NotConstructibleException> {
+            newNotConstructible2()
+        }
+    }
+}

--- a/tests/uniffi/coverall/src/commonTest/kotlin/AdditionalCoverallTest.kt
+++ b/tests/uniffi/coverall/src/commonTest/kotlin/AdditionalCoverallTest.kt
@@ -17,21 +17,25 @@ import kotlin.test.Test
 class AdditionalCoverallTest {
     @Test
     fun testPanicInsideFunctionReturningObject() {
-        shouldThrow<InternalException> {
-            NotConstructible()
-        }
-        shouldThrow<InternalException> {
-            newNotConstructible()
+        if (uniffiSupported) {
+            shouldThrow<InternalException> {
+                NotConstructible()
+            }
+            shouldThrow<InternalException> {
+                newNotConstructible()
+            }
         }
     }
 
     @Test
     fun testErrorThrownFromFunctionReturningObject() {
-        shouldThrow<NotConstructibleException> {
-            NotConstructible2()
-        }
-        shouldThrow<NotConstructibleException> {
-            newNotConstructible2()
+        if (uniffiSupported) {
+            shouldThrow<NotConstructibleException> {
+                NotConstructible2()
+            }
+            shouldThrow<NotConstructibleException> {
+                newNotConstructible2()
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes

When FFI functions returning RustArcPtrs throw an error, the null assertion applied to the FFI function invocation results in NPE before throwing the actual error. This PR moves null assertion operators used against such function calls outside the `uniffiRustCallWithError(...) { ... }`.

## Testing

Added more test cases to `:tests:uniffi:coverall`.

## Issues Fixed

Fixes: #74
