### PR TITLE
Fallback to UniffiJnaCleaner when AndroidSystemCleaner is unavailable on Android 34 or higher

### DIFF
--- a/bindgen/src/templates/android+jvm/ObjectCleanerHelper.kt
+++ b/bindgen/src/templates/android+jvm/ObjectCleanerHelper.kt
@@ -42,12 +42,17 @@ private class AndroidSystemCleanable(
     override fun clean() = cleanable.clean()
 }
 
-private fun UniffiCleaner.Companion.create(): UniffiCleaner =
+private fun UniffiCleaner.Companion.create(): UniffiCleaner {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        AndroidSystemCleaner()
-    } else {
-        UniffiJnaCleaner()
+        try {
+            return AndroidSystemCleaner()
+        } catch (_: IllegalAccessError) {
+            // (For Compose preview) Fallback to UniffiJnaCleaner if AndroidSystemCleaner is
+            // unavailable, even for API level 34 or higher.
+        }
     }
+    return UniffiJnaCleaner()
+}
 
 {%- else %}
 


### PR DESCRIPTION
## Changes

Made the Android bindings fallback to `UniffiJnaCleaner` when `AndroidSystemCleaner` is not available even for API level 34 or higher. This is for Compose preview.

## Testing

Manually tested with the Android tutorial added by #62. Needs #81 to be merged. Setting `android.render.sandbox=false` in `bin/idea.properties` is also required.

![image](https://github.com/user-attachments/assets/9516484e-d88f-4065-85bd-c2dbb67742d6)

## Issues Fixed

Fixes: #83