### PR TITLE
Make Android Studio recognize UniFFI binding directories

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -11,6 +11,7 @@ import gobley.gradle.GobleyHost
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.PluginIds
 import gobley.gradle.Variant
+import gobley.gradle.android.GobleyAndroidExtensionDelegate
 import gobley.gradle.cargo.dsl.CargoAndroidBuild
 import gobley.gradle.cargo.dsl.CargoAndroidBuildVariant
 import gobley.gradle.cargo.dsl.CargoExtension
@@ -67,7 +68,8 @@ class CargoPlugin : Plugin<Project> {
 
     @OptIn(InternalGobleyGradleApi::class)
     private lateinit var kotlinExtensionDelegate: GobleyKotlinExtensionDelegate
-    private lateinit var androidDelegate: CargoPluginAndroidDelegate
+    @OptIn(InternalGobleyGradleApi::class)
+    private lateinit var androidDelegate: GobleyAndroidExtensionDelegate
 
     override fun apply(target: Project) {
         @OptIn(InternalGobleyGradleApi::class)
@@ -124,7 +126,7 @@ class CargoPlugin : Plugin<Project> {
             kotlinExtensionDelegate.targets.configureEach { planBuilds() }
         }
         val androidPluginAction = Action<Plugin<*>> {
-            androidDelegate = CargoPluginAndroidDelegate(project)
+            androidDelegate = GobleyAndroidExtensionDelegate(project)
             val abiFilters = androidDelegate.abiFilters
             cargoExtension.androidTargetsToBuild.convention(project.provider {
                 if (abiFilters.isNotEmpty()) {
@@ -252,6 +254,7 @@ class CargoPlugin : Plugin<Project> {
                     )
                     dependsOn(rustUpTargetAddTask)
                     if (cargoBuildVariant is CargoAndroidBuildVariant) {
+                        @OptIn(InternalGobleyGradleApi::class)
                         val environmentVariables = cargoBuildVariant.rustTarget.ndkEnvVariables(
                             sdkRoot = androidDelegate.androidSdkRoot,
                             apiLevel = androidDelegate.androidMinSdk,
@@ -264,6 +267,7 @@ class CargoPlugin : Plugin<Project> {
                 cargoBuildVariant.checkTaskProvider.configure {
                     dependsOn(rustUpTargetAddTask)
                     if (cargoBuildVariant is CargoAndroidBuildVariant) {
+                        @OptIn(InternalGobleyGradleApi::class)
                         val environmentVariables = cargoBuildVariant.rustTarget.ndkEnvVariables(
                             sdkRoot = androidDelegate.androidSdkRoot,
                             apiLevel = androidDelegate.androidMinSdk,
@@ -303,6 +307,7 @@ class CargoPlugin : Plugin<Project> {
                         } else {
                             cargoBuild as CargoAndroidBuild
                             cargoBuild.dynamicLibrarySearchPaths.addAll(
+                                @OptIn(InternalGobleyGradleApi::class)
                                 cargoBuild.rustTarget.ndkLibraryDirectories(
                                     sdkRoot = androidDelegate.androidSdkRoot,
                                     apiLevel = androidDelegate.androidMinSdk,
@@ -474,6 +479,7 @@ class CargoPlugin : Plugin<Project> {
             }
         }
 
+        @OptIn(InternalGobleyGradleApi::class)
         androidDelegate.addMainJniDir(this, cargoBuildVariant.variant, copyTask, copyDestination)
 
         tasks.named("check") {

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -35,7 +35,6 @@ import gobley.gradle.tasks.useGlobalLock
 import gobley.gradle.utils.DependencyUtils
 import gobley.gradle.utils.PluginUtils
 import gobley.gradle.variant
-import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -68,6 +67,7 @@ class CargoPlugin : Plugin<Project> {
 
     @OptIn(InternalGobleyGradleApi::class)
     private lateinit var kotlinExtensionDelegate: GobleyKotlinExtensionDelegate
+
     @OptIn(InternalGobleyGradleApi::class)
     private lateinit var androidDelegate: GobleyAndroidExtensionDelegate
 
@@ -125,8 +125,8 @@ class CargoPlugin : Plugin<Project> {
             kotlinExtensionDelegate = delegate
             kotlinExtensionDelegate.targets.configureEach { planBuilds() }
         }
-        val androidPluginAction = Action<Plugin<*>> {
-            androidDelegate = GobleyAndroidExtensionDelegate(project)
+        PluginUtils.withAndroidPlugin(this) { delegate ->
+            androidDelegate = delegate
             val abiFilters = androidDelegate.abiFilters
             cargoExtension.androidTargetsToBuild.convention(project.provider {
                 if (abiFilters.isNotEmpty()) {
@@ -136,10 +136,6 @@ class CargoPlugin : Plugin<Project> {
                 }
             })
         }
-
-        // If either of the Android application plugin or the Android library plugin is present, retrieve the extension.
-        plugins.withId(PluginIds.ANDROID_APPLICATION, androidPluginAction)
-        plugins.withId(PluginIds.ANDROID_LIBRARY, androidPluginAction)
     }
 
     private fun Project.checkRequiredPlugins() {

--- a/build-logic/gobley-gradle/build.gradle.kts
+++ b/build-logic/gobley-gradle/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     compileOnly(plugin(libs.plugins.kotlin.android))
     compileOnly(plugin(libs.plugins.kotlin.jvm))
     compileOnly(plugin(libs.plugins.kotlin.multiplatform))
+    compileOnly(plugin(libs.plugins.android.application))
+    compileOnly(plugin(libs.plugins.android.library))
+
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.semver)
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
@@ -71,9 +71,9 @@ private class GobleyAndroidExtensionDelegateImpl(project: Project) :
     ) {
         androidExtension.sourceSets { sourceSets ->
             val testSourceSet = if (variant != null) {
-                sourceSets.getByVariant("test", variant)
+                sourceSets.getByVariant(variant)
             } else {
-                sourceSets.getByName("test")
+                sourceSets.getByName("main")
             }
             testSourceSet.java.srcDir(sourceDirectory)
         }

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
@@ -4,11 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package gobley.gradle.cargo
+package gobley.gradle.android
 
 import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.internal.tasks.ProcessJavaResTask
 import com.android.build.gradle.tasks.MergeSourceSetFolders
+import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.Variant
 import gobley.gradle.getByVariant
 import gobley.gradle.variant
@@ -20,35 +20,35 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import java.io.File
 
-internal interface CargoPluginAndroidDelegate {
+@InternalGobleyGradleApi
+interface GobleyAndroidExtensionDelegate {
     val androidSdkRoot: File
     val androidMinSdk: Int
     val androidNdkRoot: File?
     val androidNdkVersion: String?
     val abiFilters: Set<String>
 
-    fun addTestSourceDir(variant: Variant, resourceDirectory: Provider<Directory>)
+    fun addMainSourceDir(
+        variant: Variant? = null,
+        sourceDirectory: Provider<Directory>,
+    )
+
     fun addMainJniDir(
         project: Project,
         variant: Variant,
         jniTask: TaskProvider<*>,
         jniDirectory: Provider<Directory>,
     )
-
-    fun addUnitTestResource(
-        project: Project,
-        variant: Variant,
-        resourceTask: TaskProvider<*>,
-        resourceDirectory: Provider<List<File>>,
-    )
 }
 
-internal fun CargoPluginAndroidDelegate(project: Project): CargoPluginAndroidDelegate {
-    return CargoPluginAndroidDelegateImpl(project)
+@InternalGobleyGradleApi
+fun GobleyAndroidExtensionDelegate(project: Project): GobleyAndroidExtensionDelegate {
+    return GobleyAndroidExtensionDelegateImpl(project)
 }
 
-private class CargoPluginAndroidDelegateImpl(project: Project) :
-    CargoPluginAndroidDelegate {
+@OptIn(InternalGobleyGradleApi::class)
+private class GobleyAndroidExtensionDelegateImpl(project: Project) :
+    GobleyAndroidExtensionDelegate {
     private val androidExtension: BaseExtension = project.extensions.getByType()
 
     override val androidSdkRoot: File
@@ -65,10 +65,17 @@ private class CargoPluginAndroidDelegateImpl(project: Project) :
     override val abiFilters: Set<String>
         get() = androidExtension.defaultConfig.ndk.abiFilters
 
-    override fun addTestSourceDir(variant: Variant, resourceDirectory: Provider<Directory>) {
-        androidExtension.sourceSets {
-            val testSourceSet = getByVariant("test", variant)
-            testSourceSet.resources.srcDir(resourceDirectory)
+    override fun addMainSourceDir(
+        variant: Variant?,
+        sourceDirectory: Provider<Directory>,
+    ) {
+        androidExtension.sourceSets { sourceSets ->
+            val testSourceSet = if (variant != null) {
+                sourceSets.getByVariant("test", variant)
+            } else {
+                sourceSets.getByName("test")
+            }
+            testSourceSet.java.srcDir(sourceDirectory)
         }
     }
 
@@ -87,28 +94,9 @@ private class CargoPluginAndroidDelegateImpl(project: Project) :
             }
         }
 
-        androidExtension.sourceSets {
-            val mainSourceSet = getByVariant(variant)
+        androidExtension.sourceSets { sourceSets ->
+            val mainSourceSet = sourceSets.getByVariant(variant)
             mainSourceSet.jniLibs.srcDir(jniDirectory)
-        }
-    }
-
-    override fun addUnitTestResource(
-        project: Project,
-        variant: Variant,
-        resourceTask: TaskProvider<*>,
-        resourceDirectory: Provider<List<File>>
-    ) {
-        project.tasks.withType<ProcessJavaResTask>().configureEach {
-            if (name.contains("UnitTest") && variant == this.variant!!) {
-                dependsOn(resourceTask)
-                // Override the default behavior of AGP excluding .so files, which causes UnsatisfiedLinkError
-                // on Linux.
-                from(
-                    // Append a fileTree which only includes the Rust shared library.
-                    resourceDirectory
-                )
-            }
         }
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/PluginUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/PluginUtils.kt
@@ -8,11 +8,14 @@ package gobley.gradle.utils
 
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.PluginIds
+import gobley.gradle.android.GobleyAndroidExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinAndroidExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinJvmExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinMultiplatformExtensionDelegate
+import gobley.gradle.rust.targets.RustAndroidTarget
 import org.gradle.api.GradleException
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 @InternalGobleyGradleApi
@@ -74,6 +77,15 @@ object PluginUtils {
         }
         project.plugins.withId(PluginIds.KOTLIN_JVM) {
             action(GobleyKotlinJvmExtensionDelegate(project))
+        }
+    }
+
+    fun withAndroidPlugin(project: Project, action: (GobleyAndroidExtensionDelegate) -> Unit) {
+        project.plugins.withId(PluginIds.ANDROID_APPLICATION) {
+            action(GobleyAndroidExtensionDelegate(project))
+        }
+        project.plugins.withId(PluginIds.ANDROID_LIBRARY) {
+            action(GobleyAndroidExtensionDelegate(project))
         }
     }
 }


### PR DESCRIPTION
## Changes

- Moved `CargoPluginAndroidDelegate` to `gobley-gradle`, renaming it to `GobleyAndroidExtensionDelegate`.
- Added `PluginUtils.withAndroidPlugin`.
- Made the UniFFI plugin register the generated bindings directory to `srcDir` of the sourceSet in the Android extension.

## Testing

Manually tested with the Android tutorial added by #62.

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/24d87c0d-1061-4627-a9ec-3ebc06cb450b" />

## Issues Fixed

Fixes: #79
