### PR TITLE
Propagate desktop JVM dependencies only when invoked by Compose previews

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -444,8 +444,10 @@ class CargoPlugin : Plugin<Project> {
                     runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                 }
             }
-            if (cargoBuildVariant.variant == GradleUtils.getComposePreviewVariant(gradle)) {
-                with(kotlinExtensionDelegate.sourceSets.androidMain(cargoBuildVariant.variant)) {
+            if (cargoBuildVariant.variant == Variant.Debug
+                && cargoBuildVariant.variant == GradleUtils.getComposePreviewVariant(gradle)
+            ) {
+                with(kotlinExtensionDelegate.sourceSets.androidMain(Variant.Debug)) {
                     dependencies {
                         runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                     }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -444,6 +444,12 @@ class CargoPlugin : Plugin<Project> {
                     runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                 }
             }
+            // Only support debug mode Compose previews.
+            // Since one of the dependencies of Compose previews, androidx.compose.ui:ui-tooling,
+            // is referenced as debugImplementation in the default template generated from
+            // Android Studio, and there is relatively small chance of users requiring to use
+            // the Rust library from release mode Compose previews, let's just handle debug mode
+            // Compose previews. See #94 for details.
             if (cargoBuildVariant.variant == Variant.Debug
                 && cargoBuildVariant.variant == GradleUtils.getComposePreviewVariant(gradle)
             ) {

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -444,9 +444,8 @@ class CargoPlugin : Plugin<Project> {
                     runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                 }
             }
-            // This is for Android Compose Preview
-            if (cargoBuildVariant.variant == Variant.Debug) {
-                with(kotlinExtensionDelegate.sourceSets.androidMain(Variant.Debug)) {
+            if (cargoBuildVariant.variant == GradleUtils.getComposePreviewVariant(gradle)) {
+                with(kotlinExtensionDelegate.sourceSets.androidMain(cargoBuildVariant.variant)) {
                     dependencies {
                         runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                     }

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -261,11 +261,7 @@ class UniFfiPlugin : Plugin<Project> {
         }
 
         @OptIn(InternalGobleyGradleApi::class)
-        DependencyUtils.addUniFfiConfigTasks(
-            this,
-            mergeUniffiConfig,
-            cargoExtension.cargoPackage.map { it.manifestFile },
-        )
+        DependencyUtils.addMergedUniffiConfigArtifact(this, mergeUniffiConfig)
 
         val buildBindings = tasks.register<BuildBindingsTask>("buildBindings") {
             group = TASK_GROUP

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -24,6 +24,7 @@ import gobley.gradle.uniffi.tasks.BuildBindingsTask
 import gobley.gradle.uniffi.tasks.InstallBindgenTask
 import gobley.gradle.uniffi.tasks.MergeUniffiConfigTask
 import gobley.gradle.utils.DependencyUtils
+import gobley.gradle.utils.GradleUtils
 import gobley.gradle.utils.PluginUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -435,11 +436,14 @@ class UniFfiPlugin : Plugin<Project> {
             "net.java.dev.jna:jna:${DependencyVersions.JNA}"
         )
         val jnaVersion = jnaDependency?.version ?: DependencyVersions.JNA
-        with(kotlinExtensionDelegate.sourceSets.androidMain(Variant.Debug)) {
-            if (uniFfiExtension.addDependencies.get()) {
-                dependencies {
-                    implementation("net.java.dev.jna:jna") {
-                        version { prefer(jnaVersion) }
+        val composePreviewVariant = GradleUtils.getComposePreviewVariant(gradle)
+        if (composePreviewVariant != null) {
+            with(kotlinExtensionDelegate.sourceSets.androidMain(composePreviewVariant)) {
+                if (uniFfiExtension.addDependencies.get()) {
+                    dependencies {
+                        implementation("net.java.dev.jna:jna") {
+                            version { prefer(jnaVersion) }
+                        }
                     }
                 }
             }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/DependencyUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/DependencyUtils.kt
@@ -130,10 +130,10 @@ object DependencyUtils {
             currentProject.files(dependencies.artifacts.resolvedArtifacts.map { artifacts ->
                 artifacts.map { it.file }
             })
+        val composePreviewVariant = GradleUtils.getComposePreviewVariant(currentProject.gradle)
         PluginUtils.withKotlinPlugin(currentProject) { delegate ->
             if (delegate.androidTarget != null) {
-                // For Compose previews
-                if (variant == Variant.Debug) {
+                if (variant == composePreviewVariant) {
                     with(delegate.sourceSets.androidMain(variant)) {
                         dependencies {
                             runtimeOnly(dependencyJars)
@@ -254,12 +254,14 @@ object DependencyUtils {
             if (it.isEmpty()) currentProject.files()
             else "net.java.dev.jna:jna:${DependencyVersions.JNA}"
         }
+        val composePreviewVariant = GradleUtils.getComposePreviewVariant(currentProject.gradle)
         PluginUtils.withKotlinPlugin(currentProject) { delegate ->
             if (delegate.androidTarget != null) {
-                // For Compose previews
-                with(delegate.sourceSets.androidMain(Variant.Debug)) {
-                    dependencies {
-                        runtimeOnly(jnaDependency)
+                if (composePreviewVariant != null) {
+                    with(delegate.sourceSets.androidMain(composePreviewVariant)) {
+                        dependencies {
+                            runtimeOnly(jnaDependency)
+                        }
                     }
                 }
                 with(delegate.sourceSets.androidUnitTest) {

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/DependencyUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/DependencyUtils.kt
@@ -18,7 +18,6 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
@@ -210,27 +209,13 @@ object DependencyUtils {
                 uniffiUsage = "uniFfiConfig"
             )
         }
-        currentProject.configurations.resolvable("uniFfiCargoManifest") { configuration ->
-            configuration.addAttributes(
-                superConfiguration = uniFfiImplementationConfiguration.get(),
-                uniffiUsage = "cargoManifest"
-            )
-        }
-        currentProject.configurations.consumable("uniFfiCargoManifestConsumable") { configuration ->
-            configuration.addAttributes(
-                superConfiguration = uniFfiImplementationConfiguration.get(),
-                uniffiUsage = "cargoManifest"
-            )
-        }
     }
 
-    fun addUniFfiConfigTasks(
+    fun addMergedUniffiConfigArtifact(
         currentProject: Project,
         uniFfiConfigTask: TaskProvider<*>,
-        cargoManifest: Provider<RegularFile>,
     ) {
         currentProject.artifacts.add("uniFfiConfigurationConsumable", uniFfiConfigTask)
-        currentProject.artifacts.add("uniFfiCargoManifestConsumable", cargoManifest)
     }
 
     fun getExternalPackageUniFfiConfigurations(currentProject: Project): Provider<List<File>>? {
@@ -243,30 +228,27 @@ object DependencyUtils {
     }
 
     fun resolveUniFfiDependencies(currentProject: Project) {
-        val configuration = currentProject.configurations.findByName("uniFfiCargoManifest")
-            ?: return
-        val dependencies = configuration.incoming
-        val externalCargoManifests = dependencies.artifacts.resolvedArtifacts.map { artifacts ->
-            artifacts.map { it.file }
-        }
-        val jnaDependency = externalCargoManifests.map {
-            // Don't apply JNA when there's no dependency on UniFFI
-            if (it.isEmpty()) currentProject.files()
-            else "net.java.dev.jna:jna:${DependencyVersions.JNA}"
-        }
         val composePreviewVariant = GradleUtils.getComposePreviewVariant(currentProject.gradle)
         PluginUtils.withKotlinPlugin(currentProject) { delegate ->
             if (delegate.androidTarget != null) {
                 if (composePreviewVariant != null) {
                     with(delegate.sourceSets.androidMain(composePreviewVariant)) {
                         dependencies {
-                            runtimeOnly(jnaDependency)
+                            runtimeOnly("net.java.dev.jna:jna") {
+                                version {
+                                    it.prefer(DependencyVersions.JNA)
+                                }
+                            }
                         }
                     }
                 }
                 with(delegate.sourceSets.androidUnitTest) {
                     dependencies {
-                        runtimeOnly(jnaDependency)
+                        runtimeOnly("net.java.dev.jna:jna") {
+                            version {
+                                it.prefer(DependencyVersions.JNA)
+                            }
+                        }
                     }
                 }
             }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
@@ -7,9 +7,8 @@
 package gobley.gradle.utils
 
 import gobley.gradle.InternalGobleyGradleApi
-import org.gradle.api.Project
+import gobley.gradle.Variant
 import org.gradle.api.invocation.Gradle
-import kotlin.math.exp
 
 @InternalGobleyGradleApi
 object GradleUtils {
@@ -35,5 +34,14 @@ object GradleUtils {
 
     fun invokedByKotlinJvmBuild(gradle: Gradle): Boolean {
         return invokedByIde() && strictlyCalling(gradle, listOf(":classes"))
+    }
+
+    fun getComposePreviewVariant(gradle: Gradle): Variant? {
+        return when {
+            !invokedByIde() -> null
+            strictlyCalling(gradle, listOf(":compileDebugSources")) -> Variant.Debug
+            strictlyCalling(gradle, listOf(":compileReleaseSources")) -> Variant.Release
+            else -> null
+        }
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
@@ -16,6 +16,10 @@ object GradleUtils {
         return System.getProperty("idea.active").toBoolean()
     }
 
+    private fun invokedByIdeSync(): Boolean {
+        return invokedByIde() && System.getProperty("idea.sync.active").toBoolean()
+    }
+
     private fun strictlyCalling(
         gradle: Gradle,
         vararg expectedTaskRequests: List<String>,
@@ -44,6 +48,7 @@ object GradleUtils {
 
     fun getComposePreviewVariant(gradle: Gradle): Variant? {
         return when {
+            invokedByIdeSync() -> Variant.Debug
             !invokedByIde() -> null
             strictlyCalling(gradle, listOf(":compileDebugSources")) -> Variant.Debug
             strictlyCalling(gradle, listOf(":compileReleaseSources")) -> Variant.Release

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
@@ -21,8 +21,14 @@ object GradleUtils {
         vararg expectedTaskRequests: List<String>,
     ): Boolean {
         val taskRequests = gradle.startParameter.taskRequests.toMutableSet()
+        if (taskRequests.isEmpty()) {
+            return expectedTaskRequests.isEmpty()
+        }
         for (expectedTaskRequest in expectedTaskRequests) {
             val taskRequest = taskRequests.firstOrNull { taskRequest ->
+                if (expectedTaskRequest.size != taskRequest.args.size) {
+                    return@firstOrNull false
+                }
                 expectedTaskRequest.zip(taskRequest.args).all { (expected, actual) ->
                     actual.endsWith(expected)
                 }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
@@ -48,6 +48,15 @@ object GradleUtils {
 
     fun getComposePreviewVariant(gradle: Gradle): Variant? {
         return when {
+            // Compose previews seem to be use information from the model built during IDE sync.
+            // Since one of the dependencies of Compose previews, androidx.compose.ui:ui-tooling,
+            // is referenced as debugImplementation in the default template generated from
+            // Android Studio, and there is relatively small chance of users requiring to use
+            // the Rust library from release mode Compose previews, let's return Variant.Debug
+            // during IDE sync. See #94 for details.
+            //
+            // CargoPlugin's Project.configureJvmPostBuildTasks also considers debug mode Compose
+            // previews only.
             invokedByIdeSync() -> Variant.Debug
             !invokedByIde() -> null
             strictlyCalling(gradle, listOf(":compileDebugSources")) -> Variant.Debug


### PR DESCRIPTION
## Changes

- Added `GradleUtils.getComposePreviewVariant()`, which returns a `Variant` when the build was invoked by Compose previews.
  - It returns `Variant.Debug` during IDE sync, which effectively prevents support for release mode Compose previews. An issue for this is opened at #99.
  - It *returns* `Variant.Release` when invoked from release mode Compose previews, but since during IDE sync the JAR file for the debug build is used, the release preview tries to find the debug mode Rust dynamic library.
  - It returns `null` during normal builds.
- The Rust dynamic library JAR file and the desktop JNA are used inside `runtimeOnly` only if `GradleUtils.getComposePreviewVariant()` returns `Variant.Debug`. This makes them removed during normal builds.
- Made `DependencyUtils.resolveUniFfiDependencies` always register JNA as a dependency, as it is used inside Compose previews or unit tests so it is not included in the final app. This is to prevent resolving dependencies during configuration.

## Testing

Tested with the Android tutorial added by #62. Compose test code is as follows.

```kotlin
Column(Modifier.safeContentPadding()) {
    val url = this::class.java.classLoader
        ?.getResource("darwin-aarch64/libapp.dylib")
        ?.toString()
    if (url == null) {
        Text("NOT FOUND")
    } else {
        Text(
            AnnotatedString.Builder().apply {
                append(url)
                val debugIdx = url.indexOf("debug.jar")
                if (debugIdx != -1) {
                    addStyle(SpanStyle(color = Color.Red), debugIdx, debugIdx + 5)
                }
            }.toAnnotatedString()
        )
    }
    Text("BuildConfig.DEBUG: ${BuildConfig.DEBUG}")
    Text("JNA Version: ${Native.VERSION}")
    Text("Addition using Rust: 2 + 3 = ${uniffi.app.add(2, 3)}")
    val greeting = remember { uniffi.app.Greeter("Hello") }
    Text(greeting.greet("Rust"))
    DisposableEffect(greeting) {
        onDispose {
            greeting.close()
        }
    }
}
```

![image](https://github.com/user-attachments/assets/be198d6c-7f88-4818-8980-c0de3e7e9eb4)

Tested with a multi-module project as well.

![image](https://github.com/user-attachments/assets/6e7e51bb-6e9c-4cb1-bf08-aee09b7ddee4)

## Issues Fixed

Fixes: #92
