### PR TITLE
Fix Kotlin/JVM console project run not recognizing Rust dynamic libraries

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -46,7 +46,6 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
@@ -56,7 +55,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
-import java.io.File
 
 class CargoPlugin : Plugin<Project> {
     companion object {
@@ -339,6 +337,7 @@ class CargoPlugin : Plugin<Project> {
         val buildTask = cargoBuildVariant.buildTaskProvider
         val checkTask = cargoBuildVariant.checkTaskProvider
         val findDynamicLibrariesTask = cargoBuildVariant.findDynamicLibrariesTaskProvider
+        val jarTask = cargoBuildVariant.jarTaskProvider
         cargoBuildVariant.dynamicLibrarySearchPaths.add(
             cargoBuildVariant.profile.zip(cargoExtension.cargoPackage) { profile, cargoPackage ->
                 cargoPackage.outputDirectory(profile, cargoBuildVariant.rustTarget).asFile
@@ -348,21 +347,7 @@ class CargoPlugin : Plugin<Project> {
         findDynamicLibrariesTask.configure {
             libraryPathsCacheFile.set(projectLayout.outputCacheFile(this, "libraryPathsCacheFile"))
         }
-
-        val libraryFiles = project.objects.listProperty<File>().apply {
-            add(buildTask.flatMap { task ->
-                task.libraryFileByCrateType.map { it[CrateType.SystemDynamicLibrary]!!.asFile }
-            })
-            addAll(findDynamicLibrariesTask.flatMap { it.libraryPaths })
-        }
-
-        val jarTask = tasks.register<Jar>({
-            +"jvmRustRuntime"
-            +cargoBuildVariant
-        }) {
-            group = TASK_GROUP
-            from(libraryFiles)
-            into(cargoBuildVariant.resourcePrefix)
+        jarTask.configure {
             val variantSuffix = when (val variant = cargoBuildVariant.variant) {
                 Variant.Debug -> "-$variant"
                 else -> ""

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -33,6 +33,7 @@ import gobley.gradle.rust.targets.RustJvmTarget
 import gobley.gradle.rust.targets.RustTarget
 import gobley.gradle.tasks.useGlobalLock
 import gobley.gradle.utils.DependencyUtils
+import gobley.gradle.utils.GradleUtils
 import gobley.gradle.utils.PluginUtils
 import gobley.gradle.variant
 import org.gradle.api.GradleException
@@ -49,6 +50,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import org.gradle.language.jvm.tasks.ProcessResources
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
@@ -371,13 +373,52 @@ class CargoPlugin : Plugin<Project> {
             dependsOn(buildTask, findDynamicLibrariesTask)
         }
 
+        // For Kotlin/JVM projects without the application plugin or the Compose Multiplatform
+        // plugin, the dynamic libraries must be copied in the resources directory to be loaded
+        // during runtime. See #95.
+        //
+        // To avoid being included in the resources when class files are packaged into a JAR file,
+        // `copyLibrariesTask` is invoked only when `GradleUtils.invokedByKotlinJvmBuild()`
+        // returns `false`.
+        val resourcePrefix = cargoBuildVariant.resourcePrefix.orNull?.takeIf(String::isNotEmpty)
+        val resourceDirectory = layout.buildDirectory
+            .dir("intermediates/rust/${cargoBuildVariant.rustTarget.rustTriple}/${cargoBuildVariant.variant}")
+        val resourceCopyDestination = if (resourcePrefix == null) {
+            resourceDirectory
+        } else resourceDirectory.map {
+            it.dir(resourcePrefix)
+        }
+        val copyLibrariesTask = tasks.register<Copy>({
+            +"jvm"
+            +cargoBuildVariant
+        }) {
+            from(cargoBuildVariant.libraryFiles)
+            into(resourceCopyDestination)
+            dependsOn(buildTask, findDynamicLibrariesTask)
+        }
+
         @OptIn(InternalGobleyGradleApi::class)
         if (
             kotlinTarget !is KotlinAndroidTarget
             && cargoBuildVariant.embedRustLibrary.get()
             && cargoBuildVariant.variant == cargoBuildVariant.build.jvmVariant.get()
         ) {
+            val invokedByKotlinJvmBuild = GradleUtils.invokedByKotlinJvmBuild(gradle)
+            if (invokedByKotlinJvmBuild) {
+                val expectedTaskName = when (kotlinExtensionDelegate.pluginId) {
+                    PluginIds.KOTLIN_JVM -> "processResources"
+                    else -> "${kotlinTarget.name}ProcessResources"
+                }
+                tasks.withType<ProcessResources> {
+                    if (name == expectedTaskName) {
+                        dependsOn(copyLibrariesTask)
+                    }
+                }
+            }
             with(kotlinExtensionDelegate.sourceSets.jvmMain) {
+                if (invokedByKotlinJvmBuild) {
+                    resources.srcDir(resourceDirectory)
+                }
                 dependencies {
                     runtimeOnly(files(jarTask.flatMap { it.archiveFile }))
                 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoJvmBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoJvmBuildVariant.kt
@@ -9,10 +9,11 @@ package gobley.gradle.cargo.dsl
 import gobley.gradle.cargo.tasks.FindDynamicLibrariesTask
 import gobley.gradle.rust.targets.RustJvmTarget
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.tasks.Jar
 
 interface CargoJvmBuildVariant<out RustTargetT : RustJvmTarget> : CargoDesktopBuildVariant<RustTargetT>,
     HasDynamicLibraries, HasJvmProperties {
     override val build: CargoJvmBuild<CargoJvmBuildVariant<RustTargetT>>
-
     val findDynamicLibrariesTaskProvider: TaskProvider<FindDynamicLibrariesTask>
+    val jarTaskProvider: TaskProvider<Jar>
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoJvmBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoJvmBuildVariant.kt
@@ -8,12 +8,16 @@ package gobley.gradle.cargo.dsl
 
 import gobley.gradle.cargo.tasks.FindDynamicLibrariesTask
 import gobley.gradle.rust.targets.RustJvmTarget
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
+import java.io.File
 
-interface CargoJvmBuildVariant<out RustTargetT : RustJvmTarget> : CargoDesktopBuildVariant<RustTargetT>,
+interface CargoJvmBuildVariant<out RustTargetT : RustJvmTarget> :
+    CargoDesktopBuildVariant<RustTargetT>,
     HasDynamicLibraries, HasJvmProperties {
     override val build: CargoJvmBuild<CargoJvmBuildVariant<RustTargetT>>
     val findDynamicLibrariesTaskProvider: TaskProvider<FindDynamicLibrariesTask>
+    val libraryFiles: Provider<List<File>>
     val jarTaskProvider: TaskProvider<Jar>
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoPosixBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoPosixBuildVariant.kt
@@ -9,8 +9,13 @@ package gobley.gradle.cargo.dsl
 import gobley.gradle.Variant
 import gobley.gradle.cargo.tasks.FindDynamicLibrariesTask
 import gobley.gradle.cargo.utils.register
+import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustPosixTarget
 import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.listProperty
+import java.io.File
 import javax.inject.Inject
 
 @Suppress("LeakingThis")
@@ -36,5 +41,20 @@ abstract class CargoPosixBuildVariant @Inject constructor(
         rustTarget.set(this@CargoPosixBuildVariant.rustTarget)
         libraryNames.set(this@CargoPosixBuildVariant.dynamicLibraries)
         searchPaths.set(this@CargoPosixBuildVariant.dynamicLibrarySearchPaths)
+    }
+
+    private val libraryFiles = project.objects.listProperty<File>().apply {
+        add(buildTaskProvider.flatMap { task ->
+            task.libraryFileByCrateType.map { it[CrateType.SystemDynamicLibrary]!!.asFile }
+        })
+        addAll(findDynamicLibrariesTaskProvider.flatMap { it.libraryPaths })
+    }
+
+    override val jarTaskProvider = project.tasks.register<Jar>({
+        +"jvmRustRuntime"
+        +this@CargoPosixBuildVariant
+    }) {
+        from(libraryFiles)
+        into(resourcePrefix)
     }
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoPosixBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoPosixBuildVariant.kt
@@ -12,6 +12,7 @@ import gobley.gradle.cargo.utils.register
 import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustPosixTarget
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.listProperty
@@ -43,7 +44,7 @@ abstract class CargoPosixBuildVariant @Inject constructor(
         searchPaths.set(this@CargoPosixBuildVariant.dynamicLibrarySearchPaths)
     }
 
-    private val libraryFiles = project.objects.listProperty<File>().apply {
+    override val libraryFiles: Provider<List<File>> = project.objects.listProperty<File>().apply {
         add(buildTaskProvider.flatMap { task ->
             task.libraryFileByCrateType.map { it[CrateType.SystemDynamicLibrary]!!.asFile }
         })

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoWindowsBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoWindowsBuildVariant.kt
@@ -12,6 +12,7 @@ import gobley.gradle.cargo.utils.register
 import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustWindowsTarget
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.listProperty
 import java.io.File
@@ -41,7 +42,7 @@ abstract class CargoWindowsBuildVariant @Inject constructor(
         searchPaths.set(this@CargoWindowsBuildVariant.dynamicLibrarySearchPaths)
     }
 
-    private val libraryFiles = project.objects.listProperty<File>().apply {
+    override val libraryFiles: Provider<List<File>> = project.objects.listProperty<File>().apply {
         add(buildTaskProvider.flatMap { task ->
             task.libraryFileByCrateType.map { it[CrateType.SystemDynamicLibrary]!!.asFile }
         })

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoWindowsBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoWindowsBuildVariant.kt
@@ -9,8 +9,12 @@ package gobley.gradle.cargo.dsl
 import gobley.gradle.Variant
 import gobley.gradle.cargo.tasks.FindDynamicLibrariesTask
 import gobley.gradle.cargo.utils.register
+import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustWindowsTarget
 import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.listProperty
+import java.io.File
 import javax.inject.Inject
 
 @Suppress("LeakingThis")
@@ -35,5 +39,20 @@ abstract class CargoWindowsBuildVariant @Inject constructor(
         rustTarget.set(this@CargoWindowsBuildVariant.rustTarget)
         libraryNames.set(this@CargoWindowsBuildVariant.dynamicLibraries)
         searchPaths.set(this@CargoWindowsBuildVariant.dynamicLibrarySearchPaths)
+    }
+
+    private val libraryFiles = project.objects.listProperty<File>().apply {
+        add(buildTaskProvider.flatMap { task ->
+            task.libraryFileByCrateType.map { it[CrateType.SystemDynamicLibrary]!!.asFile }
+        })
+        addAll(findDynamicLibrariesTaskProvider.flatMap { it.libraryPaths })
+    }
+
+    override val jarTaskProvider = project.tasks.register<Jar>({
+        +"jvmRustRuntime"
+        +this@CargoWindowsBuildVariant
+    }) {
+        from(libraryFiles)
+        into(resourcePrefix)
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/GradleUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.utils
+
+import gobley.gradle.InternalGobleyGradleApi
+import org.gradle.api.Project
+import org.gradle.api.invocation.Gradle
+import kotlin.math.exp
+
+@InternalGobleyGradleApi
+object GradleUtils {
+    private fun invokedByIde(): Boolean {
+        return System.getProperty("idea.active").toBoolean()
+    }
+
+    private fun strictlyCalling(
+        gradle: Gradle,
+        vararg expectedTaskRequests: List<String>,
+    ): Boolean {
+        val taskRequests = gradle.startParameter.taskRequests.toMutableSet()
+        for (expectedTaskRequest in expectedTaskRequests) {
+            val taskRequest = taskRequests.firstOrNull { taskRequest ->
+                expectedTaskRequest.zip(taskRequest.args).all { (expected, actual) ->
+                    actual.endsWith(expected)
+                }
+            } ?: return false
+            taskRequests.remove(taskRequest)
+        }
+        return taskRequests.isEmpty()
+    }
+
+    fun invokedByKotlinJvmBuild(gradle: Gradle): Boolean {
+        return invokedByIde() && strictlyCalling(gradle, listOf(":classes"))
+    }
+}


### PR DESCRIPTION
## Changes

- Added `CargoJvmBuildVariant.{jarTaskProvider, libraryFiles}`. This is useful for users requiring custom publication logic.
- Added `GradleUtils`. This object contains heuristics to detect specific IDE use cases.
- Restored the copy task removed by #81, on which the main sourceSet's `ProcessResource` task was dependent. The dependency is active only when `GradleUtils. invokedByKotlinJvmBuild()` is true, which means it was invoked by the run button in IntelliJ/Android Studio.

## Testing

- Tested with the JVM tutorial added by #62. The project was cleaned before testing.

![image](https://github.com/user-attachments/assets/e4b1468d-4846-4d33-bb01-2f2eb97857bc)

- Tested with a multi-module project as well.

![image](https://github.com/user-attachments/assets/e97fd8eb-e277-49e7-81d7-c2d8d9d24b7e)

## Issues Fixed

Fixes: #95
