### PR TITLE
pin Rust version to v1.82.0

### DIFF
--- a/.github/workflows/dependency-image.Dockerfile
+++ b/.github/workflows/dependency-image.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74-slim
+FROM rust:1.82.0-slim
 
 # Use Clippy to detect more warnings
 RUN rustup component add clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.82.0"

--- a/tests/uniffi/callbacks/src/commonMain/rust/lib.rs
+++ b/tests/uniffi/callbacks/src/commonMain/rust/lib.rs
@@ -103,6 +103,7 @@ impl Default for RustGetters {
 #[allow(clippy::wrong_self_convention)]
 trait StoredForeignStringifier: Send + Sync + std::fmt::Debug {
     fn from_simple_type(&self, value: i32) -> String;
+    #[allow(dead_code)]
     fn from_complex_type(&self, values: Option<Vec<Option<f64>>>) -> String;
 }
 

--- a/tests/uniffi/keywords/src/commonMain/rust/lib.rs
+++ b/tests/uniffi/keywords/src/commonMain/rust/lib.rs
@@ -16,10 +16,15 @@ impl r#break {
 
 #[allow(non_camel_case_types)]
 trait r#continue {
+    #[allow(dead_code)]
     fn r#return(&self, v: r#return) -> r#return;
+    #[allow(dead_code)]
     fn r#continue(&self) -> Option<Box<dyn r#continue>>;
+    #[allow(dead_code)]
     fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
+    #[allow(dead_code)]
     fn r#while(&self, _v: Vec<r#while>) -> r#while;
+    #[allow(dead_code)]
     fn class(&self, _v: HashMap<u8, Vec<class>>) -> Option<HashMap<u8, Vec<class>>>;
 }
 


### PR DESCRIPTION
It's the last version that uses LLVM 19, so we need it for now.

## Changes

To avoid contributors hitting the cross compilation issue, pin the Rust version for now.

We can use a newer version once https://github.com/gobley/gobley/issues/48 is resolved.

## Testing

I synced the project locally without issue.