### PR TITLE
Allow passing extra arguments to `CargoCheckTask`

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuildVariant.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuildVariant.kt
@@ -48,6 +48,6 @@ abstract class DefaultCargoBuildVariant<out RustTargetT : RustTarget, out CargoB
             profile.set(this@DefaultCargoBuildVariant.profile)
             target.set(this@DefaultCargoBuildVariant.rustTarget)
             features.set(this@DefaultCargoBuildVariant.features)
-            command.convention(extension.checkCommand)
+            checkCommand.convention(extension.checkCommand)
         }
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
@@ -9,6 +9,7 @@ package gobley.gradle.cargo.tasks
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.cargo.profiles.CargoProfile
 import gobley.gradle.rust.targets.RustTarget
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
@@ -30,6 +31,9 @@ abstract class CargoCheckTask : CargoPackageTask() {
     @get:Input
     abstract val checkCommand: Property<String>
 
+    @get:Input
+    abstract val extraArguments: ListProperty<String>
+
     @TaskAction
     @OptIn(InternalGobleyGradleApi::class)
     fun check() {
@@ -42,6 +46,9 @@ abstract class CargoCheckTask : CargoPackageTask() {
                 if (features.get().isNotEmpty()) {
                     arguments("--features", features.get().joinToString(","))
                 }
+            }
+            for (extraArgument in extraArguments.get()) {
+                arguments(extraArgument)
             }
             suppressXcodeIosToolchains()
         }.get().apply {

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
@@ -32,7 +32,7 @@ abstract class CargoCheckTask : CargoPackageTask() {
 
     @TaskAction
     @OptIn(InternalGobleyGradleApi::class)
-    fun build() {
+    fun check() {
         val profile = profile.get()
         val target = target.get()
         cargo(checkCommand.get()) {

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
@@ -28,14 +28,14 @@ abstract class CargoCheckTask : CargoPackageTask() {
     abstract val features: SetProperty<String>
 
     @get:Input
-    abstract val command: Property<String>
+    abstract val checkCommand: Property<String>
 
     @TaskAction
     @OptIn(InternalGobleyGradleApi::class)
     fun build() {
         val profile = profile.get()
         val target = target.get()
-        cargo(command.get()) {
+        cargo(checkCommand.get()) {
             arguments("--profile", profile.profileName)
             arguments("--target", target.rustTriple)
             if (features.isPresent) {

--- a/examples/arithmetic-procmacro/build.gradle.kts
+++ b/examples/arithmetic-procmacro/build.gradle.kts
@@ -20,6 +20,10 @@ cargo {
                     nightly = true
                     extraArguments.add("-Zbuild-std")
                 }
+                checkTaskProvider.configure {
+                    nightly = true
+                    extraArguments.add("-Zbuild-std")
+                }
             }
         }
     }

--- a/examples/todolist/build.gradle.kts
+++ b/examples/todolist/build.gradle.kts
@@ -20,6 +20,10 @@ cargo {
                     nightly = true
                     extraArguments.add("-Zbuild-std")
                 }
+                checkTaskProvider.configure {
+                    nightly = true
+                    extraArguments.add("-Zbuild-std")
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes

- Renamed `CargoCheckTask.command` to `checkCommand` in favor of tools like `xargo` or `cross` (#68). **This doesn't mean that Gobley is going to support these tools soon.**
- Renamed `CargoCheckTask.build()` to `check()`.
- Added `CargoCheckTask.extraArguments` as did in `CargoBuildTask`.
- Passed `-Zbuild-std` to `checkTaskProvider` for tier 3 targets in `:examples:arithmetic-procmacro` and `:examples:todolist`.

## Testing

Tested manually with `:examples:arithmetic-procmacro` and `:examples:todolist` on a macOS machine.

![image](https://github.com/user-attachments/assets/691f55d1-5c79-47ea-8e88-69abcacd0b40)

## Issues Fixed

Fixes: #109
