### PR TITLE
docs: fix typo in /common-development-practices

### DIFF
--- a/docs/docs/docs/1-common-development-practices.md
+++ b/docs/docs/docs/1-common-development-practices.md
@@ -15,7 +15,7 @@ with Visual Studio Code or RustRover. In normal cases, Kotlin handles the part i
 users such as UI while Rust handles the core business logic, so using two IDEs won't harm the
 developer experience that much.
 
-Since building Rust takes much time than compiling Kotlin, try separating the Kotlin part that uses
+Since building Rust takes much more time than compiling Kotlin, try separating the Kotlin part that uses
 Rust directly as a core library. You can build and publish the core library using the
 `maven-publish` plugin and the other Kotlin part can download it from a maven repository.
 

--- a/docs/versioned_docs/version-0.1.0/docs/docs.md
+++ b/docs/versioned_docs/version-0.1.0/docs/docs.md
@@ -23,7 +23,7 @@ can use Android Studio or IntelliJ IDEA, and for Rust, you can use `rust-analyze
 In normal cases, Kotlin handles the part interacting with users such as UI while Rust handles the core business logic,
 so using two IDEs won't harm the developer experience that much.
 
-Since building Rust takes much time than compiling Kotlin, try separating the Kotlin part that uses Rust directly as a
+Since building Rust takes much more time than compiling Kotlin, try separating the Kotlin part that uses Rust directly as a
 core library. You can build and publish the core library using the `maven-publish` plugin and the other Kotlin part can
 download it from a maven repository.
 

--- a/docs/versioned_docs/version-0.2.0/docs/1-common-development-practices.md
+++ b/docs/versioned_docs/version-0.2.0/docs/1-common-development-practices.md
@@ -15,7 +15,7 @@ with Visual Studio Code or RustRover. In normal cases, Kotlin handles the part i
 users such as UI while Rust handles the core business logic, so using two IDEs won't harm the
 developer experience that much.
 
-Since building Rust takes much time than compiling Kotlin, try separating the Kotlin part that uses
+Since building Rust takes much more time than compiling Kotlin, try separating the Kotlin part that uses
 Rust directly as a core library. You can build and publish the core library using the
 `maven-publish` plugin and the other Kotlin part can download it from a maven repository.
 


### PR DESCRIPTION
## Changes

fixes a typo in the docs