### PR TITLE
Introduce DSL not to run RustUpTargetAddTasks

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -252,7 +252,9 @@ class CargoPlugin : Plugin<Project> {
                             "nativeStaticLibsDefFile"
                         )
                     )
-                    dependsOn(rustUpTargetAddTask)
+                    if (cargoBuild.installTargetBeforeBuild.get()) {
+                        dependsOn(rustUpTargetAddTask)
+                    }
                     if (cargoBuildVariant is CargoAndroidBuildVariant) {
                         @OptIn(InternalGobleyGradleApi::class)
                         val environmentVariables = cargoBuildVariant.rustTarget.ndkEnvVariables(
@@ -265,7 +267,9 @@ class CargoPlugin : Plugin<Project> {
                     }
                 }
                 cargoBuildVariant.checkTaskProvider.configure {
-                    dependsOn(rustUpTargetAddTask)
+                    if (cargoBuild.installTargetBeforeBuild.get()) {
+                        dependsOn(rustUpTargetAddTask)
+                    }
                     if (cargoBuildVariant is CargoAndroidBuildVariant) {
                         @OptIn(InternalGobleyGradleApi::class)
                         val environmentVariables = cargoBuildVariant.rustTarget.ndkEnvVariables(

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuild.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoBuild.kt
@@ -33,4 +33,12 @@ interface CargoBuild<out CargoBuildVariantT : CargoBuildVariant<RustTarget>>
      * The Cargo command to use for linting. If you want to Clippy, set this to `clippy`.
      */
     val checkCommand: Property<String>
+
+    /**
+     * When `true`, the pre-built standard library for the target will be installed via the
+     * `rustup target add` command before building or linting. This is turned off for tier 3 targets
+     * by default. If you are using a custom target whose tier cannot be determined, set this
+     * property to `false`.
+     */
+    val installTargetBeforeBuild: Property<Boolean>
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoExtension.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/CargoExtension.kt
@@ -141,4 +141,13 @@ abstract class CargoExtension(final override val project: Project) : HasProject,
      */
     val publishJvmArtifacts: Property<Boolean> =
         project.objects.property<Boolean>().convention(true)
+
+    /**
+     * When `true`, the pre-built standard library for the target will be installed via the
+     * `rustup target add` command before building or linting. This is turned off for tier 3 targets
+     * by default. If you are using a custom target whose tier cannot be determined, set this
+     * property to `false`.
+     */
+    val installTargetBeforeBuild: Property<Boolean> =
+        project.objects.property<Boolean>().convention(true)
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuild.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/dsl/DefaultCargoBuild.kt
@@ -47,5 +47,6 @@ abstract class DefaultCargoBuild<out RustTargetT : RustTarget, out CargoBuildVar
         @Suppress("LeakingThis")
         features.addAll(extension.features)
         checkCommand.convention(extension.checkCommand)
+        installTargetBeforeBuild.convention(extension.installTargetBeforeBuild)
     }
 }

--- a/docs/docs/docs/2-gradle-plugins/1-cargo-plugin.md
+++ b/docs/docs/docs/2-gradle-plugins/1-cargo-plugin.md
@@ -501,11 +501,36 @@ cargo {
 }
 ```
 
+## Disabling automatic installation of pre-built standard libraries
+
+By default, the Cargo plugin installs the pre-built standard library of the specified target via the
+`rustup target add` command before initiating a build. For example, if your library targets AArch64
+Android, the plugin will run `rustup target add aarch64-linux-android` before building.
+
+While this behavior is convenient in most scenarios, some users using a custom target may have
+trouble setting their build. To address such cases, the Cargo plugin offers the
+`installTargetBeforeBuild` property, which defaults to `true`. If you set it to `false`, the plugin
+will skip the `rustup target add` step before building. You can configure this property globally or
+on a per-target basis, as shown below:
+
+```kotlin
+cargo {
+    // Disable `rustup target add` for all targets
+    installTargetBeforeBuild = false
+    // Alternatively, disable `rustup target add` for a specific target (e.g. Android)
+    builds.android {
+        // installTargetBeforeBuild is inherited from the one in the `cargo {}` block 
+        installTargetBeforeBuild = false
+    }
+}
+```
+
 ## Enabling the nightly mode and building tier 3 Rust targets
 
 Some targets like tvOS and watchOS are tier 3 in the Rust world (they are tier 2 on the Kotlin
-side). Pre-built standard libraries are not available for these targets. To use the standard
-library, you must pass the `-Zbuild-std` flag to the `cargo build` command (
+side). Pre-built standard libraries are not available for these targets, and the Cargo plugin does
+not invoke the `rustup target add` for them. To use the standard library, you must pass the
+`-Zbuild-std` flag to the `cargo build` command (
 See [here](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) for the official
 documentation). Since this flag is available only on the nightly channel, you should tell the Cargo
 plugin to use the nightly compiler to compile the standard library.

--- a/docs/docs/docs/2-gradle-plugins/1-cargo-plugin.md
+++ b/docs/docs/docs/2-gradle-plugins/1-cargo-plugin.md
@@ -529,7 +529,7 @@ cargo {
 
 Some targets like tvOS and watchOS are tier 3 in the Rust world (they are tier 2 on the Kotlin
 side). Pre-built standard libraries are not available for these targets, and the Cargo plugin does
-not invoke the `rustup target add` for them. To use the standard library, you must pass the
+not invoke the `rustup target add` command for them. To use the standard library, you must pass the
 `-Zbuild-std` flag to the `cargo build` command (
 See [here](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) for the official
 documentation). Since this flag is available only on the nightly channel, you should tell the Cargo


### PR DESCRIPTION
## Changes

- Added a DSL property, `installTargetBeforeBuild`, to `CargoExtension` and `CargoBuild`.
- Made the Cargo plugin register dependencies from `CargoBuildTask` and `CargoCheckTask` on `RustUpTargetTask` only when `installTargetBeforeBuild` is set to `true`.

```kotlin
cargo {
  installTargetBeforeBuild = false
  // or
  builds.android {
    installTargetBeforeBuild = false
  }
}
```

## Testing

Tested manually.

### `CargoExtension.installTargetBeforeBuild`

| Without `installTargetBeforeBuild = false` | With it |
| - | - |
| <img width="661" alt="image" src="https://github.com/user-attachments/assets/4123d865-3357-4d8e-b2ac-b7f0ccf5ef32" /> | <img width="616" alt="image" src="https://github.com/user-attachments/assets/311ac561-b67b-4a8f-8c00-50cb43ab8b6f" /> |

### `CargoBuild.installTargetBeforeBuild`

| `installTargetBeforeBuild = false` in another `CargoBuild` | `installTargetBeforeBuild = false` in the right `CargoBuild |
| - | - |
| <img width="641" alt="image" src="https://github.com/user-attachments/assets/ac063f6d-b0d7-457a-ab35-8805a63b2198" /> | <img width="631" alt="image" src="https://github.com/user-attachments/assets/f5c6f336-5a49-40ae-be8d-f60f285452b6" /> |

## Issues Fixed

Fixes: #130
