### PR TITLE
Generate ProGuard rules for UniFFI users

### DIFF
--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -316,7 +316,6 @@ class UniFfiPlugin : Plugin<Project> {
                 project,
                 androidGeneratedProGuardFile.get(),
                 tasks.register<GenerateProGuardRulesTask>("generateProGuardRules") {
-                    packageName.set(bindingsGeneration.packageName)
                     outputFile.set(androidGeneratedProGuardFile)
                 },
             )

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -21,6 +21,7 @@ import gobley.gradle.uniffi.dsl.BindingsGenerationFromLibrary
 import gobley.gradle.uniffi.dsl.BindingsGenerationFromUdl
 import gobley.gradle.uniffi.dsl.UniFfiExtension
 import gobley.gradle.uniffi.tasks.BuildBindingsTask
+import gobley.gradle.uniffi.tasks.GenerateProGuardRulesTask
 import gobley.gradle.uniffi.tasks.InstallBindgenTask
 import gobley.gradle.uniffi.tasks.MergeUniffiConfigTask
 import gobley.gradle.utils.DependencyUtils
@@ -308,6 +309,18 @@ class UniFfiPlugin : Plugin<Project> {
         tasks.withType<CInteropProcess> {
             dependsOn(buildBindings)
         }
+
+        @OptIn(InternalGobleyGradleApi::class)
+        if (uniFfiExtension.generateProGuardRules.get() && ::androidDelegate.isInitialized) {
+            androidDelegate.addProGuardFiles(
+                project,
+                androidGeneratedProGuardFile.get(),
+                tasks.register<GenerateProGuardRulesTask>("generateProGuardRules") {
+                    packageName.set(bindingsGeneration.packageName)
+                    outputFile.set(androidGeneratedProGuardFile)
+                },
+            )
+        }
     }
 
     private fun Project.configureCleanTasks() {
@@ -513,6 +526,9 @@ private val Project.nativeBindingsDirectory: Provider<Directory>
 
 private val Project.stubBindingsDirectory: Provider<Directory>
     get() = bindingsDirectory.map { it.dir("stubMain/kotlin") }
+
+private val Project.androidGeneratedProGuardFile: Provider<RegularFile>
+    get() = bindingsDirectory.map { it.file("androidMain/generated-proguard-rules.txt") }
 
 private val Project.nativeBindingsCInteropDirectory: Provider<Directory>
     get() = bindingsDirectory.map { it.dir("nativeInterop/cinterop") }

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/UniFfiExtension.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/UniFfiExtension.kt
@@ -43,6 +43,15 @@ abstract class UniFfiExtension(internal val project: Project) {
         project.objects.property<Boolean>().convention(true)
 
     /**
+     * When `true`, the UniFFI plugin will generate a ProGuard rule file for the Android target.
+     * The generated file will automatically appended to `proguardFile` or `consumerProguardFile`
+     * inside the `android.buildTypes {}` block, depending on whether the current module is
+     * an application project or a library project.
+     */
+    val generateProGuardRules: Property<Boolean> =
+        project.objects.property<Boolean>().convention(true)
+
+    /**
      * Install the bindgen of the given [version] from the given [registry]. If [registry] is not specified, this will
      * download the bindgen from `crates.io`.
      */

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/GenerateProGuardRulesTask.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/GenerateProGuardRulesTask.kt
@@ -7,32 +7,14 @@
 package gobley.gradle.uniffi.tasks
 
 import gobley.gradle.tasks.AbstractFileGenerationTask
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 
 @CacheableTask
 abstract class GenerateProGuardRulesTask : AbstractFileGenerationTask() {
-    @get:Input
-    @get:Optional
-    abstract val packageName: Property<String>
-
-    @Suppress("LeakingThis")
-    override val desiredOutput: Provider<String> =
-        packageName.orElse("").map(::generateOutput)
-
-    companion object {
-        private fun generateOutput(packageName: String?) = StringBuilder().apply {
-            appendLine("-keep class com.sun.jna.** { *; }")
-            appendLine(
-                when (packageName) {
-                    null, "" -> "-keep class * implements com.sun.jna.** { *; }"
-                    else -> "-keep class ${packageName}.** implements com.sun.jna.** { *; }"
-                }
-            )
-            appendLine("-dontwarn java.awt.**")
-        }.toString()
-    }
+    override fun getDesiredOutput() = StringBuilder().apply {
+        appendLine("# Copied from https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android")
+        appendLine("-dontwarn java.awt.*")
+        appendLine("-keep class com.sun.jna.* { *; }")
+        appendLine("-keepclassmembers class * extends com.sun.jna.* { public *; }")
+    }.toString()
 }

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/GenerateProGuardRulesTask.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/GenerateProGuardRulesTask.kt
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.uniffi.tasks
+
+import gobley.gradle.tasks.AbstractFileGenerationTask
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+@CacheableTask
+abstract class GenerateProGuardRulesTask : AbstractFileGenerationTask() {
+    @get:Input
+    @get:Optional
+    abstract val packageName: Property<String>
+
+    @Suppress("LeakingThis")
+    override val desiredOutput: Provider<String> =
+        packageName.orElse("").map(::generateOutput)
+
+    companion object {
+        private fun generateOutput(packageName: String?) = StringBuilder().apply {
+            appendLine("-keep class com.sun.jna.** { *; }")
+            appendLine(
+                when (packageName) {
+                    null, "" -> "-keep class * implements com.sun.jna.** { *; }"
+                    else -> "-keep class ${packageName}.** implements com.sun.jna.** { *; }"
+                }
+            )
+            appendLine("-dontwarn java.awt.**")
+        }.toString()
+    }
+}

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
@@ -6,6 +6,9 @@
 
 package gobley.gradle.android
 
+import com.android.build.api.dsl.ApplicationBuildType
+import com.android.build.api.dsl.BuildType
+import com.android.build.api.dsl.LibraryBuildType
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.MergeSourceSetFolders
 import gobley.gradle.InternalGobleyGradleApi
@@ -14,6 +17,7 @@ import gobley.gradle.getByVariant
 import gobley.gradle.variant
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByType
@@ -38,6 +42,12 @@ interface GobleyAndroidExtensionDelegate {
         variant: Variant,
         jniTask: TaskProvider<*>,
         jniDirectory: Provider<Directory>,
+    )
+
+    fun addProGuardFiles(
+        project: Project,
+        proGuardFile: RegularFile,
+        generationTask: TaskProvider<*>,
     )
 }
 
@@ -97,6 +107,36 @@ private class GobleyAndroidExtensionDelegateImpl(project: Project) :
         androidExtension.sourceSets { sourceSets ->
             val mainSourceSet = sourceSets.getByVariant(variant)
             mainSourceSet.jniLibs.srcDir(jniDirectory)
+        }
+    }
+
+    override fun addProGuardFiles(
+        project: Project,
+        proGuardFile: RegularFile,
+        generationTask: TaskProvider<*>,
+    ) {
+        androidExtension.buildTypes.configureEach { buildType ->
+            if (buildType.isMinifyEnabled) {
+                addProGuardFilesToBuildType(project, proGuardFile, buildType, generationTask)
+            }
+        }
+    }
+
+    private fun addProGuardFilesToBuildType(
+        project: Project,
+        proGuardFile: RegularFile,
+        buildType: BuildType,
+        generationTask: TaskProvider<*>,
+    ) {
+        // For some reason, androidExtension.buildTypes.getByName returns a internal BuildType
+        // that implements both ApplicationBuildType and LibraryBuildType.
+
+        if (buildType is ApplicationBuildType) {
+            buildType.proguardFile(proGuardFile)
+        }
+
+        if (buildType is LibraryBuildType) {
+            buildType.consumerProguardFile(proGuardFile)
         }
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
@@ -10,6 +10,7 @@ import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.LibraryBuildType
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.internal.tasks.MergeConsumerProguardFilesTask
 import com.android.build.gradle.tasks.MergeSourceSetFolders
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.Variant
@@ -116,9 +117,7 @@ private class GobleyAndroidExtensionDelegateImpl(project: Project) :
         generationTask: TaskProvider<*>,
     ) {
         androidExtension.buildTypes.configureEach { buildType ->
-            if (buildType.isMinifyEnabled) {
-                addProGuardFilesToBuildType(project, proGuardFile, buildType, generationTask)
-            }
+            addProGuardFilesToBuildType(project, proGuardFile, buildType, generationTask)
         }
     }
 
@@ -137,6 +136,11 @@ private class GobleyAndroidExtensionDelegateImpl(project: Project) :
 
         if (buildType is LibraryBuildType) {
             buildType.consumerProguardFile(proGuardFile)
+            project.tasks.withType<MergeConsumerProguardFilesTask> {
+                if (name.lowercase().contains(buildType.name.lowercase())) {
+                    dependsOn(generationTask)
+                }
+            }
         }
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/tasks/AbstractFileGenerationTask.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/tasks/AbstractFileGenerationTask.kt
@@ -8,7 +8,7 @@ package gobley.gradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -16,12 +16,13 @@ abstract class AbstractFileGenerationTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
-    protected abstract val desiredOutput: Provider<String>
+    @Internal
+    protected abstract fun getDesiredOutput(): String
 
     init {
         outputs.upToDateWhen {
             val outputFile = outputFile.asFile.get()
-            outputFile.exists() && outputFile.isFile && outputFile.readText(Charsets.UTF_8) == desiredOutput.get()
+            outputFile.exists() && outputFile.isFile && outputFile.readText(Charsets.UTF_8) == getDesiredOutput()
         }
     }
 
@@ -29,6 +30,6 @@ abstract class AbstractFileGenerationTask : DefaultTask() {
     fun generateFile() {
         val outputFile = outputFile.asFile.get()
         outputFile.parentFile?.mkdirs()
-        outputFile.writeText(desiredOutput.get())
+        outputFile.writeText(getDesiredOutput())
     }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/tasks/AbstractFileGenerationTask.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/tasks/AbstractFileGenerationTask.kt
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class AbstractFileGenerationTask : DefaultTask() {
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    protected abstract val desiredOutput: Provider<String>
+
+    init {
+        outputs.upToDateWhen {
+            val outputFile = outputFile.asFile.get()
+            outputFile.exists() && outputFile.isFile && outputFile.readText(Charsets.UTF_8) == desiredOutput.get()
+        }
+    }
+
+    @TaskAction
+    fun generateFile() {
+        val outputFile = outputFile.asFile.get()
+        outputFile.parentFile?.mkdirs()
+        outputFile.writeText(desiredOutput.get())
+    }
+}

--- a/examples/arithmetic-procmacro/proguard-rules.pro
+++ b/examples/arithmetic-procmacro/proguard-rules.pro
@@ -1,4 +1,0 @@
-# Copied from https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
--dontwarn java.awt.*
--keep class com.sun.jna.* { *; }
--keepclassmembers class * extends com.sun.jna.* { public *; }

--- a/examples/custom-types/proguard-rules.pro
+++ b/examples/custom-types/proguard-rules.pro
@@ -1,4 +1,0 @@
-# Copied from https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
--dontwarn java.awt.*
--keep class com.sun.jna.* { *; }
--keepclassmembers class * extends com.sun.jna.* { public *; }

--- a/examples/todolist/proguard-rules.pro
+++ b/examples/todolist/proguard-rules.pro
@@ -1,4 +1,0 @@
-# Copied from https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
--dontwarn java.awt.*
--keep class com.sun.jna.* { *; }
--keepclassmembers class * extends com.sun.jna.* { public *; }

--- a/examples/tokio-blake3-app/proguard-rules.pro
+++ b/examples/tokio-blake3-app/proguard-rules.pro
@@ -1,4 +1,0 @@
-# Copied from https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
--dontwarn java.awt.*
--keep class com.sun.jna.* { *; }
--keepclassmembers class * extends com.sun.jna.* { public *; }


### PR DESCRIPTION
## Changes

- Added a boolean property, `UniFfiExtension.generateProGuardRules`, which controls the generation of ProGuard rule files.
- Added `AbstractFileGenerationTask`.
- Added `GenerateProGuardRulesTask`.
- wip

## Testing

> Ignore this field if this PR does not change the functionality of the source
> code (e.g., documentation typo correction) or fixes a minor bug.
>
> If you've added unit tests for your changes, please list the names of the unit
> tests here. If they're hard to manage by automation, please describe the
> procedure to reproduce the test result. If you need to modify some code just
> to do the test, please put the diff of that modification here.

*UNIT TEST NAMES OR TEST PROCEDURES HERE*

## Issues Fixed

Fixes: #21
