### PR TITLE
Remove code using `CargoCheckTask.extraArguments` from the 0.2.0 docs

### DIFF
--- a/docs/versioned_docs/version-0.2.0/docs/2-gradle-plugins/1-cargo-plugin.md
+++ b/docs/versioned_docs/version-0.2.0/docs/2-gradle-plugins/1-cargo-plugin.md
@@ -530,11 +530,6 @@ cargo {
                     // Make Cargo build the standard library
                     extraArguments.add("-Zbuild-std")
                 }
-                // You can configure for the check task as well
-                checkTaskProvider.configure {
-                    nightly = true
-                    extraArguments.add("-Zbuild-std")
-                }
             }
         }
     }


### PR DESCRIPTION
#123 mistakenly added a description about `CargoCheckTask.extraArgument` to the 0.2.0 docs, which was added in #110 and merged after the 0.2.0 release. This PR reverts that change.