### PR TITLE
Generate local error handlers for external exception types

### DIFF
--- a/bindgen/src/templates/android+jvm/ExternalTypeTemplate.kt
+++ b/bindgen/src/templates/android+jvm/ExternalTypeTemplate.kt
@@ -1,6 +1,8 @@
 
 {%- let namespace = ci.namespace_for_module_path(module_path)? %}
 {%- let package_name=self.external_type_package_name(module_path, namespace) %}
+{%- include "ffi/ExternalTypeTemplate.kt" %}
+
 {%- let fully_qualified_type_name = "{}.{}"|format(package_name, name|class_name(ci)) %}
 {%- let fully_qualified_ffi_converter_name = "{}.FfiConverterType{}"|format(package_name, name) %}
 {%- let fully_qualified_rustbuffer_name = "{}.RustBuffer"|format(package_name) %}
@@ -12,6 +14,22 @@
 {{- self.add_import(fully_qualified_ffi_converter_name) }}
 {{ self.add_import_as(fully_qualified_rustbuffer_name, local_rustbuffer_name) }}
 {{ self.add_import_as(fully_qualified_rustbuffer_by_value_name, local_rustbuffer_by_value_name) }}
+
+fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
+    return {{ local_rustbuffer_by_value_name }}(
+        capacity = capacity,
+        len = len,
+        data = data,
+    )
+}
+
+fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByValue {
+    return RustBufferByValue(
+        capacity = capacity,
+        len = len,
+        data = data,
+    )
+}
 
 fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{ name|class_name(ci) }} {
     return read({{ package_name }}.ByteBuffer(buf.internal()))

--- a/bindgen/src/templates/android+jvm/Helpers.kt
+++ b/bindgen/src/templates/android+jvm/Helpers.kt
@@ -2,8 +2,8 @@
 
 @Structure.FieldOrder("code", "errorBuf")
 internal open class UniffiRustCallStatusStruct(
-    @JvmField internal var code: Byte,
-    @JvmField internal var errorBuf: RustBufferByValue,
+    @JvmField var code: Byte,
+    @JvmField var errorBuf: RustBufferByValue,
 ) : Structure() {
     constructor(): this(0.toByte(), RustBufferByValue())
 

--- a/bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
+++ b/bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
@@ -21,7 +21,7 @@ internal interface {{ callback.name()|ffi_callback_name }}: com.sun.jna.Callback
 @Structure.FieldOrder({% for field in ffi_struct.fields() %}"{{ field.name()|var_name_raw }}"{% if !loop.last %}, {% endif %}{% endfor %})
 internal open class {{ ffi_struct.name()|ffi_struct_name }}Struct(
     {%- for field in ffi_struct.fields() %}
-    @JvmField internal var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }},
+    @JvmField var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }},
     {%- endfor %}
 ) : com.sun.jna.Structure() {
     constructor(): this(

--- a/bindgen/src/templates/android+jvm/RustBufferTemplate.kt
+++ b/bindgen/src/templates/android+jvm/RustBufferTemplate.kt
@@ -4,9 +4,9 @@
 open class RustBufferStruct(
     // Note: `capacity` and `len` are actually `ULong` values, but JVM only supports signed values.
     // When dealing with these fields, make sure to call `toULong()`.
-    @JvmField internal var capacity: Long,
-    @JvmField internal var len: Long,
-    @JvmField internal var data: Pointer?,
+    @JvmField var capacity: Long,
+    @JvmField var len: Long,
+    @JvmField var data: Pointer?,
 ) : Structure() {
     constructor(): this(0.toLong(), 0.toLong(), null)
 
@@ -73,8 +73,8 @@ internal fun RustBufferByReference.getValue(): RustBufferByValue {
 
 @Structure.FieldOrder("len", "data")
 internal open class ForeignBytesStruct : Structure() {
-    @JvmField internal var len: Int = 0
-    @JvmField internal var data: Pointer? = null
+    @JvmField var len: Int = 0
+    @JvmField var data: Pointer? = null
 
     internal class ByValue : ForeignBytes(), Structure.ByValue
 }

--- a/bindgen/src/templates/ffi/ExternalTypeTemplate.kt
+++ b/bindgen/src/templates/ffi/ExternalTypeTemplate.kt
@@ -1,0 +1,8 @@
+{%- if ci.is_name_used_as_error(name) %}
+{%- let class_name = name|class_name(ci) %}
+
+object {{ class_name }}ErrorHandler : UniffiRustCallStatusErrorHandler<{{ class_name }}> {
+    override fun lift(errorBuf: RustBufferByValue): {{ class_name }} = {{ package_name }}.{{ class_name }}ErrorHandler.lift(errorBuf.as{{ name }}())
+}
+
+{%- endif %}

--- a/bindgen/src/templates/macros.kt
+++ b/bindgen/src/templates/macros.kt
@@ -48,14 +48,6 @@
 {%- endmacro -%}
 
 {%- macro func_decl(func_decl, callable, indent, is_decl_override) %}
-    {%- if (!self::throws_external_error(callable, ci)) %}
-        {%- call render_func_decl(func_decl, callable, indent, is_decl_override) %}
-    {%- else %}
-// Sorry, the callable "{{ callable.name() }}" isn't supported.
-    {%- endif %}
-{%- endmacro -%}
-
-{%- macro render_func_decl(func_decl, callable, indent, is_decl_override) %}
                         {%- call docstring(callable, indent) -%}
                         {%- match callable.throws_type() -%}
                         {%-     when Some(throwable) %}
@@ -74,14 +66,6 @@
 {% endmacro %}
 
 {%- macro func_decl_with_body(func_decl, callable, indent) %}
-    {%- if (!self::throws_external_error(callable, ci)) %}
-        {%- call render_func_decl_with_body(func_decl, callable, indent) %}
-    {%- else %}
-// Sorry, the callable "{{ callable.name() }}" isn't supported.
-    {%- endif %}
-{%- endmacro -%}
-
-{%- macro render_func_decl_with_body(func_decl, callable, indent) %}
                         {%- call docstring(callable, indent) -%}
                         {%- match callable.throws_type() -%}
                         {%-     when Some(throwable) %}
@@ -111,14 +95,6 @@
 {% endmacro %}
 
 {%- macro func_decl_with_stub(func_decl, callable, indent) %}
-    {%- if (!self::throws_external_error(callable, ci)) %}
-        {%- call render_func_decl_with_stub(func_decl, callable, indent) %}
-    {%- else %}
-// Sorry, the callable "{{ callable.name() }}" isn't supported.
-    {%- endif %}
-{%- endmacro -%}
-
-{%- macro render_func_decl_with_stub(func_decl, callable, indent) %}
                         {%- call docstring(callable, indent) %}
 {{ " "|repeat(indent) }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
                         {%- if callable.is_async() -%}suspend {% endif -%}

--- a/bindgen/src/templates/native/ExternalTypeTemplate.kt
+++ b/bindgen/src/templates/native/ExternalTypeTemplate.kt
@@ -1,6 +1,8 @@
 
 {%- let namespace = ci.namespace_for_module_path(module_path)? %}
 {%- let package_name=self.external_type_package_name(module_path, namespace) %}
+{%- include "ffi/ExternalTypeTemplate.kt" %}
+
 {%- let fully_qualified_type_name = "{}.{}"|format(package_name, name|class_name(ci)) %}
 {%- let fully_qualified_ffi_converter_name = "{}.FfiConverterType{}"|format(package_name, name) %}
 {%- let fully_qualified_capacity = "{}.capacity"|format(package_name) %}

--- a/tests/uniffi/ext-types/ext-types/src/commonTest/kotlin/ExtTypesTest.kt
+++ b/tests/uniffi/ext-types/ext-types/src/commonTest/kotlin/ExtTypesTest.kt
@@ -7,7 +7,9 @@
 import kotlin.test.Test
 import ext_types.*
 import custom_types.*
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import sub_lib.*
 import uniffi_one.*
 import io.ktor.http.Url
@@ -70,6 +72,21 @@ class ExtTypesTest {
         getMaybeUniffiOneEnum(null) shouldBe null
         getUniffiOneEnums(listOf(uoe)) shouldBe listOf(uoe)
         getMaybeUniffiOneEnums(listOf(uoe, null)) shouldBe listOf(uoe, null)
+
+        run {
+            val e = shouldThrow<UniffiOneException> {
+                throwUniffiOneError()
+            }
+            e.shouldBeTypeOf<UniffiOneException.Oops>()
+            e.v1 shouldBe "oh no"
+        }
+
+        run {
+            val e = shouldThrow<UniffiOneErrorInterface> {
+                throwUniffiOneErrorInterface()
+            }
+            e.message() shouldBe "interface oops"
+        }
 
         ct.ecd.sval shouldBe "ecd"
         getExternalCrateInterface("foo").value() shouldBe "foo"


### PR DESCRIPTION
## Changes

The bindgen now:
- Generates local error handlers for external exception types, which can be accepted by local `uniffiRustCallWithError`.
- Makes struct fields public on JVM platforms.

## Testing

- Added unit test cases for external type throwing to `:ext-types:ext-types`.

## Issues Fixed

Fixes: #146
