### PR TITLE
Properly handle incoming artifacts of configurations

### DIFF
--- a/docs/docs/docs/2-gradle-plugins/3-rust-plugin.md
+++ b/docs/docs/docs/2-gradle-plugins/3-rust-plugin.md
@@ -72,10 +72,9 @@ feature, Gobley
 uses [Gradle configurations](https://docs.gradle.org/8.13/userguide/declaring_configurations.html)
 to propagate dynamic libraries built with Cargo for JVM targets and UniFFI configurations
 for [external types](https://mozilla.github.io/uniffi-rs/0.29/types/remote_ext_types.html). When a project
-that uses the Cargo or the UniFFI plugins references or referenced by another project, the Rust
-plugin should be also applied to that project. If you don't apply the Rust plugin, you might
-encounter a runtime error during Android local unit tests, or a configuration not found error
-during IDE sync. Simply apply the Rust plugin to resolve these issues.
+that uses the Cargo or the UniFFI plugins are referenced by another project, the Rust plugin should
+be also applied to that project. If you don't apply the Rust plugin, you might encounter a runtime
+error during Android local unit tests. Simply apply the Rust plugin to resolve these issues.
 
 ```kotlin
 plugins {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ if (ext.propertyIsTrue("gobley.projects.uniffiTests")) {
     include(":tests:uniffi:coverall")
     include(":tests:uniffi:coverall-android")
     include(":tests:uniffi:coverall-jvm")
+    include(":tests:uniffi:coverall-pure-kotlin-dep")
     include(":tests:uniffi:docstring")
     include(":tests:uniffi:docstring-proc-macro")
     include(":tests:uniffi:enum-types")

--- a/tests/uniffi/coverall-pure-kotlin-dep/build.gradle.kts
+++ b/tests/uniffi/coverall-pure-kotlin-dep/build.gradle.kts
@@ -1,0 +1,50 @@
+// Tests whether projects with Gobley plugins can depend on other pure-Kotlin projects
+// without the Rust plugin.
+
+import gobley.gradle.GobleyHost
+import gobley.gradle.rust.dsl.hostNativeTarget
+import gobley.gradle.rust.dsl.useRustUpLinker
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    kotlin("multiplatform")
+    // Don't apply the Rust plugin; this is to use GobleyHost below.
+    id("dev.gobley.rust") apply false
+}
+
+kotlin {
+    jvmToolchain(17)
+    jvm()
+    hostNativeTarget {
+        if (GobleyHost.Platform.Windows.isCurrent) {
+            compilations.getByName("test") {
+                useRustUpLinker()
+            }
+        }
+    }
+    js {
+        nodejs()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadlessNoSandbox()
+                }
+            }
+        }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadlessNoSandbox()
+                }
+            }
+        }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
+}

--- a/tests/uniffi/coverall-pure-kotlin-dep/src/commonMain/kotlin/PureKotlinLibrary.kt
+++ b/tests/uniffi/coverall-pure-kotlin-dep/src/commonMain/kotlin/PureKotlinLibrary.kt
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+object PureKotlinLibrary {
+    fun add(lhs: Int, rhs: Int) = lhs + rhs
+}

--- a/tests/uniffi/coverall/build.gradle.kts
+++ b/tests/uniffi/coverall/build.gradle.kts
@@ -37,4 +37,12 @@ kotlin {
     // wasmWasi {
     //     nodejs()
     // }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(project(":tests:uniffi:coverall-pure-kotlin-dep"))
+            }
+        }
+    }
 }

--- a/tests/uniffi/coverall/src/commonTest/kotlin/PureKotlinDependencyTest.kt
+++ b/tests/uniffi/coverall/src/commonTest/kotlin/PureKotlinDependencyTest.kt
@@ -1,0 +1,17 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+// Tests whether projects with Gobley plugins can depend on other pure-Kotlin projects
+// without the Rust plugin.
+class PureKotlinDependencyTest {
+    @Test
+    fun canDependOnPureKotlinProject() {
+        PureKotlinLibrary.add(3, 5) shouldBe 8
+    }
+}


### PR DESCRIPTION
## Changes

- Added checks for the attribute value of incoming artifacts of the `rustRuntimeOnly` and the `uniFfiImplementation` configurations.
- This removes the need to apply the Rust plugin to pure-Kotlin libraries that Rust projects depend on.

## Testing

- Added `:tests:uniffi:coverall-pure-kotlin-dep`.
- Made `:tests:uniffi:coverall` depend on it.

## Issues Fixed

Fixes: #119, Fixes: #155
