### PR TITLE
Fix the UniFFI versions in 0.3 tutorials

### DIFF
--- a/docs/docs/tutorial/0-tutorial.md
+++ b/docs/docs/tutorial/0-tutorial.md
@@ -100,7 +100,7 @@ Let's add a Cargo package to the Kotlin Multiplatform project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.4"
 
    # This as well.
    [lib]
@@ -111,7 +111,7 @@ Let's add a Cargo package to the Kotlin Multiplatform project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.4"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib", "staticlib"]` will make Cargo generate a `.a` (static library) file
       and a `.so`/`.dylib` (dynamic library) file that can be used by Gobley. Gobley uses the static

--- a/docs/docs/tutorial/1-tutorial-android.md
+++ b/docs/docs/tutorial/1-tutorial-android.md
@@ -92,7 +92,7 @@ Let's add a Cargo package to the Android project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.4"
 
    # This as well.
    [lib]
@@ -103,7 +103,7 @@ Let's add a Cargo package to the Android project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.4"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib"]` will make Cargo generate a `.so` (dynamic library) file that can be
       used by Gobley.

--- a/docs/docs/tutorial/2-tutorial-jvm.md
+++ b/docs/docs/tutorial/2-tutorial-jvm.md
@@ -93,7 +93,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.4"
 
    # This as well.
    [lib]
@@ -104,7 +104,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.4"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib"]` will make Cargo generate a `.dll` (Windows), `.dylib` (macOS), or
       `.so` (Linux) file that can be used by Gobley.

--- a/docs/docs/tutorial/3-tutorial-native.md
+++ b/docs/docs/tutorial/3-tutorial-native.md
@@ -86,7 +86,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.4"
 
    # This as well.
    [lib]

--- a/docs/versioned_docs/version-0.3/tutorial/0-tutorial.md
+++ b/docs/versioned_docs/version-0.3/tutorial/0-tutorial.md
@@ -100,7 +100,7 @@ Let's add a Cargo package to the Kotlin Multiplatform project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.3"
 
    # This as well.
    [lib]
@@ -111,7 +111,7 @@ Let's add a Cargo package to the Kotlin Multiplatform project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib", "staticlib"]` will make Cargo generate a `.a` (static library) file
       and a `.so`/`.dylib` (dynamic library) file that can be used by Gobley. Gobley uses the static

--- a/docs/versioned_docs/version-0.3/tutorial/1-tutorial-android.md
+++ b/docs/versioned_docs/version-0.3/tutorial/1-tutorial-android.md
@@ -92,7 +92,7 @@ Let's add a Cargo package to the Android project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.3"
 
    # This as well.
    [lib]
@@ -103,7 +103,7 @@ Let's add a Cargo package to the Android project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib"]` will make Cargo generate a `.so` (dynamic library) file that can be
       used by Gobley.

--- a/docs/versioned_docs/version-0.3/tutorial/2-tutorial-jvm.md
+++ b/docs/versioned_docs/version-0.3/tutorial/2-tutorial-jvm.md
@@ -93,7 +93,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.3"
 
    # This as well.
    [lib]
@@ -104,7 +104,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    Let's see what each part of the modification does:
 
-    - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+    - `uniffi = "0.29.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
       bindings") that calls the Rust library.
     - `crate-type = ["cdylib"]` will make Cargo generate a `.dll` (Windows), `.dylib` (macOS), or
       `.so` (Linux) file that can be used by Gobley.

--- a/docs/versioned_docs/version-0.3/tutorial/3-tutorial-native.md
+++ b/docs/versioned_docs/version-0.3/tutorial/3-tutorial-native.md
@@ -86,7 +86,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    [dependencies]
    # We need to add this.
-   uniffi = "0.28.3"
+   uniffi = "0.29.3"
 
    # This as well.
    [lib]
@@ -97,7 +97,7 @@ Let's add a Cargo package to the Kotlin/JVM project.
 
    Let's see what each part of the modification does:
 
-   - `uniffi = "0.28.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
+   - `uniffi = "0.29.3"` downloads UniFFI, the library used to generate the Kotlin code (the "
      bindings") that calls the Rust library.
    - `crate-type = ["staticlib"]` will make Cargo generate a `.lib` (Windows) or a `.a` (macOS &
      Linux) file that can be used by Gobley.


### PR DESCRIPTION
0.3.0 uses UniFFI 0.29.3. 0.3.1 uses 0.29.4. When 0.3.1 is published, 0.3 tutorials will also use UniFFI 0.29.4.