### PR TITLE
Fix/uniffi explicit api public

### DIFF
--- a/build-logic/conventions/src/main/kotlin/uniffi-tests.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/uniffi-tests.gradle.kts
@@ -17,6 +17,10 @@ cargo {
     )
 }
 
+kotlin {
+    explicitApi()
+}
+
 uniffi {
     bindgenFromPath(rootProject.layout.projectDirectory.dir("crates/gobley-uniffi-bindgen"))
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/Async.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/Async.kt
@@ -1,6 +1,6 @@
 {% include "ffi/Async.kt" %}
 
-object uniffiRustFutureContinuationCallbackCallback: UniffiRustFutureContinuationCallback {
+internal object uniffiRustFutureContinuationCallbackCallback: UniffiRustFutureContinuationCallback {
     override fun callback(data: Long, pollResult: Byte) {
         uniffiContinuationHandleMap.remove(data).resume(pollResult)
     }
@@ -8,7 +8,7 @@ object uniffiRustFutureContinuationCallbackCallback: UniffiRustFutureContinuatio
 
 {%- if ci.has_async_callback_interface_definition() %}
 
-object uniffiForeignFutureFreeImpl: UniffiForeignFutureFree {
+internal object uniffiForeignFutureFreeImpl: UniffiForeignFutureFree {
     override fun callback(handle: Long) {
         val job = uniffiForeignFutureHandleMap.remove(handle)
         if (!job.isCompleted) {

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ByteBuffer.kt
@@ -1,64 +1,61 @@
 
 @kotlin.jvm.JvmInline
-value class ByteBuffer(private val inner: java.nio.ByteBuffer) {
+{{ visibility() }}value class ByteBuffer(private val inner: java.nio.ByteBuffer) {
     init {
         inner.order(java.nio.ByteOrder.BIG_ENDIAN)
     }
 
-    fun internal() = inner
+    {{ visibility() }}fun internal(): java.nio.ByteBuffer = inner
 
-    fun limit() = inner.limit()
+    {{ visibility() }}fun limit(): Int = inner.limit()
 
-    fun position() = inner.position()
+    {{ visibility() }}fun position(): Int = inner.position()
 
-    fun hasRemaining() = inner.hasRemaining()
+    {{ visibility() }}fun hasRemaining(): Boolean = inner.hasRemaining()
 
-    fun get() = inner.get()
+    {{ visibility() }}fun get(): Byte = inner.get()
 
-    fun get(bytesToRead: Int): ByteArray = ByteArray(bytesToRead).apply(inner::get)
+    {{ visibility() }}fun get(bytesToRead: Int): ByteArray = ByteArray(bytesToRead).apply(inner::get)
 
-    fun getShort() = inner.getShort()
+    {{ visibility() }}fun getShort(): Short = inner.getShort()
 
-    fun getInt() = inner.getInt()
+    {{ visibility() }}fun getInt(): Int = inner.getInt()
 
-    fun getLong() = inner.getLong()
+    {{ visibility() }}fun getLong(): Long = inner.getLong()
 
-    fun getFloat() = inner.getFloat()
+    {{ visibility() }}fun getFloat(): Float = inner.getFloat()
 
-    fun getDouble() = inner.getDouble()
+    {{ visibility() }}fun getDouble(): Double = inner.getDouble()
 
-
-
-    fun put(value: Byte) {
+    {{ visibility() }}fun put(value: Byte) {
         inner.put(value)
     }
 
-    fun put(src: ByteArray) {
+    {{ visibility() }}fun put(src: ByteArray) {
         inner.put(src)
     }
 
-    fun putShort(value: Short) {
+    {{ visibility() }}fun putShort(value: Short) {
         inner.putShort(value)
     }
 
-    fun putInt(value: Int) {
+    {{ visibility() }}fun putInt(value: Int) {
         inner.putInt(value)
     }
 
-    fun putLong(value: Long) {
+    {{ visibility() }}fun putLong(value: Long) {
         inner.putLong(value)
     }
 
-    fun putFloat(value: Float) {
+    {{ visibility() }}fun putFloat(value: Float) {
         inner.putFloat(value)
     }
 
-    fun putDouble(value: Double) {
+    {{ visibility() }}fun putDouble(value: Double) {
         inner.putDouble(value)
     }
 
-
-    fun writeUtf8(value: String) {
+    {{ visibility() }}fun writeUtf8(value: String) {
         Charsets.UTF_8.newEncoder().run {
             onMalformedInput(java.nio.charset.CodingErrorAction.REPLACE)
             encode(java.nio.CharBuffer.wrap(value), inner, false)

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/CallbackInterfaceTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/CallbackInterfaceTemplate.kt
@@ -9,4 +9,4 @@
 
 {% include "CallbackInterfaceImpl.kt" %}
 
-object {{ ffi_converter_name }} : FfiConverterCallbackInterface<{{ interface_name }}>()
+{{ visibility() }}object {{ ffi_converter_name }} : FfiConverterCallbackInterface<{{ interface_name }}>()

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ExternalTypeTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ExternalTypeTemplate.kt
@@ -15,7 +15,7 @@
 {{ self.add_import_as(fully_qualified_rustbuffer_name, local_rustbuffer_name) }}
 {{ self.add_import_as(fully_qualified_rustbuffer_by_value_name, local_rustbuffer_by_value_name) }}
 
-fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
+internal fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
     return {{ local_rustbuffer_by_value_name }}(
         capacity = capacity,
         len = len,
@@ -23,7 +23,7 @@ fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
     )
 }
 
-fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByValue {
+internal fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByValue {
     return RustBufferByValue(
         capacity = capacity,
         len = len,
@@ -31,10 +31,10 @@ fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByVa
     )
 }
 
-fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{ name|class_name(ci) }} {
+internal fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{ name|class_name(ci) }} {
     return read({{ package_name }}.ByteBuffer(buf.internal()))
 }
 
-fun {{ fully_qualified_ffi_converter_name }}.write{{ name }}(value: {{ name|class_name(ci) }}, buf: ByteBuffer) {
+internal fun {{ fully_qualified_ffi_converter_name }}.write{{ name }}(value: {{ name|class_name(ci) }}, buf: ByteBuffer) {
     write(value, {{ package_name }}.ByteBuffer(buf.internal()))
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/HandleMap.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/HandleMap.kt
@@ -3,23 +3,23 @@ internal class UniffiHandleMap<T: Any> {
     private val map = java.util.concurrent.ConcurrentHashMap<Long, T>()
     private val counter: kotlinx.atomicfu.AtomicLong = kotlinx.atomicfu.atomic(1L)
 
-    val size: Int
+    internal val size: Int
         get() = map.size
 
     // Insert a new object into the handle map and get a handle for it
-    fun insert(obj: T): Long {
+    internal fun insert(obj: T): Long {
         val handle = counter.getAndAdd(1)
         map[handle] = obj
         return handle
     }
 
     // Get an object from the handle map
-    fun get(handle: Long): T {
+    internal fun get(handle: Long): T {
         return map[handle] ?: throw InternalException("UniffiHandleMap.get: Invalid handle")
     }
 
     // Remove an entry from the handlemap and get the Kotlin object back
-    fun remove(handle: Long): T {
+    internal fun remove(handle: Long): T {
         return map.remove(handle) ?: throw InternalException("UniffiHandleMap.remove: Invalid handle")
     }
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/Helpers.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/Helpers.kt
@@ -2,22 +2,22 @@
 
 @Structure.FieldOrder("code", "errorBuf")
 internal open class UniffiRustCallStatusStruct(
-    @JvmField var code: Byte,
-    @JvmField var errorBuf: RustBufferByValue,
+    @JvmField public var code: Byte,
+    @JvmField public var errorBuf: RustBufferByValue,
 ) : Structure() {
-    constructor(): this(0.toByte(), RustBufferByValue())
+    internal constructor(): this(0.toByte(), RustBufferByValue())
 
     internal class ByValue(
         code: Byte,
         errorBuf: RustBufferByValue,
     ): UniffiRustCallStatusStruct(code, errorBuf), Structure.ByValue {
-        constructor(): this(0.toByte(), RustBufferByValue())
+        internal constructor(): this(0.toByte(), RustBufferByValue())
     }
     internal class ByReference(
         code: Byte,
         errorBuf: RustBufferByValue,
     ): UniffiRustCallStatusStruct(code, errorBuf), Structure.ByReference {
-        constructor(): this(0.toByte(), RustBufferByValue())
+        internal constructor(): this(0.toByte(), RustBufferByValue())
     }
 }
 
@@ -25,8 +25,8 @@ internal typealias UniffiRustCallStatus = UniffiRustCallStatusStruct.ByReference
 internal typealias UniffiRustCallStatusByValue = UniffiRustCallStatusStruct.ByValue
 
 internal object UniffiRustCallStatusHelper {
-    fun allocValue() = UniffiRustCallStatusByValue()
-    fun <U> withReference(block: (UniffiRustCallStatus) -> U): U {
+    internal fun allocValue() = UniffiRustCallStatusByValue()
+    internal fun <U> withReference(block: (UniffiRustCallStatus) -> U): U {
         val status = UniffiRustCallStatus()
         return block(status)
     }

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
@@ -5,7 +5,7 @@
 {%- match def %}
 {%- when FfiDefinition::CallbackFunction(callback) %}
 internal interface {{ callback.name()|ffi_callback_name }}: com.sun.jna.Callback {
-    fun callback(
+    public fun callback(
         {%- for arg in callback.arguments() -%}
         {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value(ci) }},
         {%- endfor -%}
@@ -21,10 +21,10 @@ internal interface {{ callback.name()|ffi_callback_name }}: com.sun.jna.Callback
 @Structure.FieldOrder({% for field in ffi_struct.fields() %}"{{ field.name()|var_name_raw }}"{% if !loop.last %}, {% endif %}{% endfor %})
 internal open class {{ ffi_struct.name()|ffi_struct_name }}Struct(
     {%- for field in ffi_struct.fields() %}
-    @JvmField var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }},
+    @JvmField public var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }},
     {%- endfor %}
 ) : com.sun.jna.Structure() {
-    constructor(): this(
+    internal constructor(): this(
         {% for field in ffi_struct.fields() %}
         {{ field.name()|var_name }} = {{ field.type_()|ffi_default_value }},
         {% endfor %}
@@ -178,6 +178,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
 }
 {%- endif %}
 
-fun uniffiEnsureInitialized() {
+{{ visibility() }}fun uniffiEnsureInitialized() {
     UniffiLib.INSTANCE
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ReferenceHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ReferenceHelper.kt
@@ -1,14 +1,8 @@
 
-typealias ByteByReference = com.sun.jna.ptr.ByteByReference
-
-typealias DoubleByReference = com.sun.jna.ptr.DoubleByReference
-
-typealias FloatByReference = com.sun.jna.ptr.FloatByReference
-
-typealias IntByReference = com.sun.jna.ptr.IntByReference
-
-typealias LongByReference = com.sun.jna.ptr.LongByReference
-
-typealias PointerByReference = com.sun.jna.ptr.PointerByReference
-
-typealias ShortByReference = com.sun.jna.ptr.ShortByReference
+internal typealias ByteByReference = com.sun.jna.ptr.ByteByReference
+internal typealias DoubleByReference = com.sun.jna.ptr.DoubleByReference
+internal typealias FloatByReference = com.sun.jna.ptr.FloatByReference
+internal typealias IntByReference = com.sun.jna.ptr.IntByReference
+internal typealias LongByReference = com.sun.jna.ptr.LongByReference
+internal typealias PointerByReference = com.sun.jna.ptr.PointerByReference
+internal typealias ShortByReference = com.sun.jna.ptr.ShortByReference

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/RustBufferTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/RustBufferTemplate.kt
@@ -1,21 +1,21 @@
 {% include "ffi/RustBufferTemplate.kt" %}
 
 @Structure.FieldOrder("capacity", "len", "data")
-open class RustBufferStruct(
+{{ visibility() }}open class RustBufferStruct(
     // Note: `capacity` and `len` are actually `ULong` values, but JVM only supports signed values.
     // When dealing with these fields, make sure to call `toULong()`.
-    @JvmField var capacity: Long,
-    @JvmField var len: Long,
-    @JvmField var data: Pointer?,
+    @JvmField {{ visibility() }}var capacity: Long,
+    @JvmField {{ visibility() }}var len: Long,
+    @JvmField {{ visibility() }}var data: Pointer?,
 ) : Structure() {
-    constructor(): this(0.toLong(), 0.toLong(), null)
+    {{ visibility() }}constructor(): this(0.toLong(), 0.toLong(), null)
 
-    class ByValue(
+    {{ visibility() }}class ByValue(
         capacity: Long,
         len: Long,
         data: Pointer?,
     ): RustBuffer(capacity, len, data), Structure.ByValue {
-        constructor(): this(0.toLong(), 0.toLong(), null)
+        {{ visibility() }}constructor(): this(0.toLong(), 0.toLong(), null)
     }
 
     /**
@@ -24,17 +24,17 @@ open class RustBufferStruct(
      *
      * Size is the sum of all values in the struct.
      */
-    class ByReference(
+    {{ visibility() }}class ByReference(
         capacity: Long,
         len: Long,
         data: Pointer?,
     ): RustBuffer(capacity, len, data), Structure.ByReference {
-        constructor(): this(0.toLong(), 0.toLong(), null)
+        {{ visibility() }}constructor(): this(0.toLong(), 0.toLong(), null)
     }
 }
 
-typealias RustBuffer = RustBufferStruct
-typealias RustBufferByValue = RustBufferStruct.ByValue
+{{ visibility() }}typealias RustBuffer = RustBufferStruct
+{{ visibility() }}typealias RustBufferByValue = RustBufferStruct.ByValue
 
 internal fun RustBuffer.asByteBuffer(): ByteBuffer? {
     {% call kt::check_rust_buffer_length("this.len") %}
@@ -62,8 +62,6 @@ internal fun RustBufferByReference.getValue(): RustBufferByValue {
     value.writeField("data", pointer.getLong(16))
     return value
 }
-
-
 
 // This is a helper for safely passing byte references into the rust code.
 // It's not actually used at the moment, because there aren't many things that you

--- a/crates/gobley-uniffi-bindgen/src/templates/common/CustomTypeTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/CustomTypeTemplate.kt
@@ -7,7 +7,7 @@
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
-typealias {{ type_name }} = {{ builtin|type_name(ci) }}
+{{ visibility() }}typealias {{ type_name }} = {{ builtin|type_name(ci) }}
 
 {%- when Some(config) %}
 
@@ -21,7 +21,7 @@ typealias {{ type_name }} = {{ builtin|type_name(ci) }}
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
-typealias {{ type_name }} = {{ concrete_type_name }}
+{{ visibility() }}typealias {{ type_name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}
 

--- a/crates/gobley-uniffi-bindgen/src/templates/common/EnumTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/EnumTemplate.kt
@@ -14,42 +14,42 @@
 {% match e.variant_discr_type() %}
 {% when None %}
 {% if should_generate_serializable %}@kotlinx.serialization.Serializable{% endif %}
-enum class {{ type_name }} {
+{{ visibility() }}enum class {{ type_name }} {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}
     {{ variant|variant_name(config) }}{% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
-    companion object
+    {{ visibility() }}companion object
 }
 {% when Some(variant_discr_type) %}
 {% if should_generate_serializable %}@kotlinx.serialization.Serializable{% endif %}
-enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
+{{ visibility() }}enum class {{ type_name }}(public val value: {{ variant_discr_type|type_name(ci) }}) {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}
     {{ variant|variant_name(config) }}({{ e|variant_discr_literal(loop.index0) }}){% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
-    companion object
+    {{ visibility() }}companion object
 }
 {% endmatch %}
 {% else %}
 
 {%- call kt::docstring(e, 0) %}
 {% if should_generate_serializable %}@kotlinx.serialization.Serializable{% endif %}
-sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% endif %} {
+{{ visibility() }}sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {%- let variant_type_name = variant|variant_type_name(ci) -%}
     {%- let should_generate_variant_serializable = config.generate_serializable() && variant|serializable_enum_variant(ci) -%}
     {%- call kt::docstring(variant, 4) %}
     {%- if !variant.has_fields() %}
     {% if should_generate_variant_serializable %}@kotlinx.serialization.Serializable{% endif %}
-    {% if config.use_data_objects() %}data {% endif %}object {{ variant_type_name }} : {{ type_name }}() {% if contains_object_references %} {
-        override fun destroy() = Unit
+    {{ visibility() }}{% if config.use_data_objects() %}data {% endif %}object {{ variant_type_name }} : {{ type_name }}() {% if contains_object_references %} {
+        override fun destroy(): Unit = Unit
     }
     {% endif %}
     {% else -%}
     {%- let should_generate_equals_hash_code = variant|should_generate_equals_hash_code_enum_variant -%}
     {% if should_generate_variant_serializable %}@kotlinx.serialization.Serializable{% endif %}
-    data class {{ variant_type_name }}(
+    {{ visibility() }}data class {{ variant_type_name }}(
         {%- for field in variant.fields() -%}
         {%- call kt::docstring(field, 8) %}
         val {% call kt::field_name(field, loop.index) %}: {{ field|type_name(ci) }},

--- a/crates/gobley-uniffi-bindgen/src/templates/common/ErrorTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/ErrorTemplate.kt
@@ -5,25 +5,25 @@
 
 {% if e.is_flat() %}
 {%- call kt::docstring(e, 0) %}
-sealed class {{ type_name }}(message: String): kotlin.Exception(message){% if contains_object_references %}, Disposable {% endif %} {
+{{ visibility() }}sealed class {{ type_name }}(message: String): kotlin.Exception(message){% if contains_object_references %}, Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}
-    class {{ variant|error_variant_name }}(message: String) : {{ type_name }}(message)
+    {{ visibility() }}class {{ variant|error_variant_name }}(message: String) : {{ type_name }}(message)
     {% endfor %}
 }
 {%- else %}
 {%- call kt::docstring(e, 0) %}
-sealed class {{ type_name }}: kotlin.Exception(){% if contains_object_references %}, Disposable {% endif %} {
+{{ visibility() }}sealed class {{ type_name }}: kotlin.Exception(){% if contains_object_references %}, Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}
     {%- let variant_name = variant|error_variant_name %}
-    class {{ variant_name }}(
+    {{ visibility() }}class {{ variant_name }}(
         {%- for field in variant.fields() -%}
         {%- call kt::docstring(field, 8) %}
-        val {% call kt::field_name(field, loop.index) %}: {{ field|type_name(ci) }},
+        {{ visibility() }}val {% call kt::field_name(field, loop.index) %}: {{ field|type_name(ci) }},
         {%- endfor %}
     ) : {{ type_name }}() {
-        override val message
+        override val message: String
             get() = "{%- for field in variant.fields() %}{% call kt::field_name_unquoted(field, loop.index) %}=${ {% call kt::field_name(field, loop.index) %} }{% if !loop.last %}, {% endif %}{% endfor %}"
         {%- if contains_object_references %}
 

--- a/crates/gobley-uniffi-bindgen/src/templates/common/Helpers.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/Helpers.kt
@@ -1,1 +1,1 @@
-class InternalException(message: String) : kotlin.Exception(message)
+{{ visibility() }}class InternalException(message: String) : kotlin.Exception(message)

--- a/crates/gobley-uniffi-bindgen/src/templates/common/Interface.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/Interface.kt
@@ -1,8 +1,8 @@
 
 {%- call kt::docstring_value(interface_docstring, 0) %}
-interface {{ interface_name }} {
+{{ visibility() }}interface {{ interface_name }} {
     {% for meth in methods.iter() -%}
     {%- call kt::func_decl("", meth, 4, true) %}
     {% endfor %}
-    companion object
+    {{ visibility() }}companion object
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/common/ObjectTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/ObjectTemplate.kt
@@ -11,9 +11,9 @@
 {% if config.kotlin_multiplatform %}
 {% call kt::docstring(obj, 0) %}
 {% if (is_error) %}
-expect open class {{ impl_class_name }} : kotlin.Exception, Disposable, {{ interface_name }} {
+{{ visibility() }}expect open class {{ impl_class_name }} : kotlin.Exception, Disposable, {{ interface_name }} {
 {% else -%}
-expect open class {{ impl_class_name }}: Disposable, {{ interface_name }}
+{{ visibility() }}expect open class {{ impl_class_name }}: Disposable, {{ interface_name }}
 {%- for t in obj.trait_impls() -%}
 , {{ self::trait_interface_name(ci, t.trait_name)? }}
 {%- endfor %} {
@@ -33,7 +33,7 @@ expect open class {{ impl_class_name }}: Disposable, {{ interface_name }}
     {%- when None %}
     @Suppress("ConvertSecondaryConstructorToPrimary")
     {%- endmatch %}
-    constructor(noPointer: NoPointer)
+    {{ visibility() }}constructor(noPointer: NoPointer)
 
     {% match obj.primary_constructor() -%}
     {%- when Some(cons) -%}
@@ -41,7 +41,7 @@ expect open class {{ impl_class_name }}: Disposable, {{ interface_name }}
     // Note no constructor generated for this object as it is async.
     {%     else -%}
     {%- call kt::docstring(cons, 4) %}
-    constructor({% call kt::arg_list(cons, true) -%})
+    {{ visibility() }}constructor({% call kt::arg_list(cons, true) -%})
     {%-     endif %}
     {%- when None %}
     {%- endmatch %}
@@ -68,13 +68,13 @@ expect open class {{ impl_class_name }}: Disposable, {{ interface_name }}
 
     {# XXX - "companion object" confusion? How to have alternate constructors *and* be an error? #}
     {%- if !obj.alternate_constructors().is_empty() -%}
-    companion object {
+    {{ visibility() }}companion object {
         {% for cons in obj.alternate_constructors() -%}
         {%- call kt::func_decl("", cons, 8, false) %}
         {% endfor %}
     }
     {% else %}
-    companion object
+    {{ visibility() }}companion object
     {%- endif %}
 }
 {% endif %}

--- a/crates/gobley-uniffi-bindgen/src/templates/common/RecordTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/RecordTemplate.kt
@@ -6,7 +6,7 @@
 {%- if rec.has_fields() %}
 {%- call kt::docstring(rec, 0) %}
 {% if should_generate_serializable %}@kotlinx.serialization.Serializable{% endif %}
-data class {{ type_name }} (
+{{ visibility() }}data class {{ type_name }} (
     {%- for field in rec.fields() %}
     {%- call kt::docstring(field, 4) %}
     {% if config.generate_immutable_records() %}val{% else %}var{% endif %} {{ field.name()|var_name }}: {{ field|type_name(ci) -}}
@@ -25,9 +25,9 @@ data class {{ type_name }} (
         {%- call kt::destroy_fields(rec, 8) %}
     }
     {%- endif %}
-    companion object
+    {{ visibility() }}companion object
 }
 {%- else -%}
 {%- call kt::docstring(rec, 0) %}
-{% if config.use_data_objects() %}data {% endif %}object {{ type_name }}
+{{ visibility() }}{% if config.use_data_objects() %}data {% endif %}object {{ type_name }}
 {%- endif %}

--- a/crates/gobley-uniffi-bindgen/src/templates/common/Types.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/common/Types.kt
@@ -10,10 +10,10 @@
 // The easiest way to ensure this method is called is to use the `.use`
 // helper method to execute a block and destroy the object at the end.
 @OptIn(ExperimentalStdlibApi::class)
-interface Disposable : AutoCloseable {
-    fun destroy()
-    override fun close() = destroy()
-    companion object {
+{{ visibility() }}interface Disposable : AutoCloseable {
+    {{ visibility() }}fun destroy()
+    override fun close(): Unit = destroy()
+    {{ visibility() }}companion object {
         internal fun destroy(vararg args: Any?) {
             for (arg in args) {
                 when (arg) {
@@ -54,7 +54,7 @@ interface Disposable : AutoCloseable {
 }
 
 @OptIn(kotlin.contracts.ExperimentalContracts::class)
-inline fun <T : Disposable?, R> T.use(block: (T) -> R): R {
+{{ visibility() }}inline fun <T : Disposable?, R> T.use(block: (T) -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }
@@ -71,7 +71,7 @@ inline fun <T : Disposable?, R> T.use(block: (T) -> R): R {
 }
 
 /** Used to instantiate an interface without an actual pointer, for fakes in tests, mostly. */
-object NoPointer
+{{ visibility() }}object NoPointer
 
 {%- for type_ in ci.iter_local_types() %}
 {%- let type_name = type_|type_name(ci) %}

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/BooleanHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/BooleanHelper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
+{{ visibility() }}object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
         return value.toInt() != 0
     }
@@ -12,7 +12,7 @@ object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
         return if (value) 1.toByte() else 0.toByte()
     }
 
-    override fun allocationSize(value: Boolean) = 1UL
+    override fun allocationSize(value: Boolean): ULong = 1UL
 
     override fun write(value: Boolean, buf: ByteBuffer) {
         buf.put(lower(value))

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/ByteArrayHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/ByteArrayHelper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
+{{ visibility() }}object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
     override fun read(buf: ByteBuffer): ByteArray {
         val len = buf.getInt()
         val byteArr = buf.get(len)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/CallbackInterfaceRuntime.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/CallbackInterfaceRuntime.kt
@@ -5,7 +5,7 @@ internal const val UNIFFI_CALLBACK_SUCCESS = 0
 internal const val UNIFFI_CALLBACK_ERROR = 1
 internal const val UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
-abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConverter<CallbackInterface, Long> {
+{{ visibility() }}abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConverter<CallbackInterface, Long> {
     internal val handleMap = UniffiHandleMap<CallbackInterface>()
 
     internal fun drop(handle: Long) {
@@ -16,11 +16,11 @@ abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConvert
         return handleMap.get(value)
     }
 
-    override fun read(buf: ByteBuffer) = lift(buf.getLong())
+    override fun read(buf: ByteBuffer): CallbackInterface = lift(buf.getLong())
 
-    override fun lower(value: CallbackInterface) = handleMap.insert(value)
+    override fun lower(value: CallbackInterface): Long = handleMap.insert(value)
 
-    override fun allocationSize(value: CallbackInterface) = 8UL
+    override fun allocationSize(value: CallbackInterface): ULong = 8UL
 
     override fun write(value: CallbackInterface, buf: ByteBuffer) {
         buf.putLong(lower(value))

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/CustomTypeTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/CustomTypeTemplate.kt
@@ -2,7 +2,7 @@
 {%- match config.custom_types.get(name.as_str())  %}
 {%- when None %}
 
-typealias {{ ffi_converter_name }} = {{ builtin|ffi_converter_name }}
+{{ visibility() }}typealias {{ ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 
 {%- when Some(config) %}
 
@@ -18,7 +18,7 @@ typealias {{ ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 {%- else %}
 {%- endmatch %}
 
-object {{ ffi_converter_name }}: FfiConverter<{{ type_name }}, {{ ffi_type_name }}> {
+{{ visibility() }}object {{ ffi_converter_name }}: FfiConverter<{{ type_name }}, {{ ffi_type_name }}> {
     override fun lift(value: {{ ffi_type_name }}): {{ type_name }} {
         val builtinValue = {{ builtin|lift_fn }}(value)
         return {{ config.lift("builtinValue") }}

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/DurationHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/DurationHelper.kt
@@ -2,7 +2,7 @@
 {{ self.add_import("kotlin.time.Duration.Companion.nanoseconds") }}
 {{ self.add_import("kotlin.time.Duration.Companion.seconds") }}
 
-object FfiConverterDuration: FfiConverterRustBuffer<kotlin.time.Duration> {
+{{ visibility() }}object FfiConverterDuration: FfiConverterRustBuffer<kotlin.time.Duration> {
     override fun read(buf: ByteBuffer): kotlin.time.Duration {
         // Type mismatch (should be u64) but we check for overflow/underflow below
         val secs = buf.getLong()
@@ -18,7 +18,7 @@ object FfiConverterDuration: FfiConverterRustBuffer<kotlin.time.Duration> {
     }
 
     // 8 bytes for seconds, 4 bytes for nanoseconds
-    override fun allocationSize(value: kotlin.time.Duration) = 12UL
+    override fun allocationSize(value: kotlin.time.Duration): ULong = 12UL
 
     override fun write(value: kotlin.time.Duration, buf: ByteBuffer) {
         if (value < 0.nanoseconds) {

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/EnumTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/EnumTemplate.kt
@@ -8,8 +8,8 @@
 
 {%- if e.is_flat() %}
 
-object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
-    override fun read(buf: ByteBuffer) = try {
+{{ visibility() }}object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
+    override fun read(buf: ByteBuffer): {{ type_name }} = try {
         {%- if config.use_enum_entries() %}
         {{ type_name }}.entries[buf.getInt() - 1]
         {%- else %}
@@ -19,7 +19,7 @@ object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
         throw RuntimeException("invalid enum value, something is very wrong!!", e)
     }
 
-    override fun allocationSize(value: {{ type_name }}) = 4UL
+    override fun allocationSize(value: {{ type_name }}): ULong = 4UL
 
     override fun write(value: {{ type_name }}, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
@@ -28,7 +28,7 @@ object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
 
 {%- else %}
 
-object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
+{{ visibility() }}object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
     override fun read(buf: ByteBuffer): {{ type_name }} {
         return when(buf.getInt()) {
             {%- for variant in e.variants() %}
@@ -42,7 +42,7 @@ object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
         }
     }
 
-    override fun allocationSize(value: {{ type_name }}) = when(value) {
+    override fun allocationSize(value: {{ type_name }}): ULong = when(value) {
         {%- for variant in e.variants() %}
         is {{ type_name }}.{{ variant|variant_type_name(ci) }} -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/ErrorTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/ErrorTemplate.kt
@@ -3,11 +3,11 @@
 {%- let ffi_converter_name = type_|ffi_converter_name %}
 {%- let canonical_type_name = type_|canonical_name %}
 
-object {{ type_name }}ErrorHandler : UniffiRustCallStatusErrorHandler<{{ type_name }}> {
+{{ visibility() }}object {{ type_name }}ErrorHandler : UniffiRustCallStatusErrorHandler<{{ type_name }}> {
     override fun lift(errorBuf: RustBufferByValue): {{ type_name }} = {{ ffi_converter_name }}.lift(errorBuf)
 }
 
-object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}> {
+{{ visibility() }}object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         {%- if e.is_flat() %}
         return when (buf.getInt()) {

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/ExternalTypeTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/ExternalTypeTemplate.kt
@@ -1,7 +1,7 @@
 {%- if ci.is_name_used_as_error(name) %}
 {%- let class_name = name|class_name(ci) %}
 
-object {{ class_name }}ErrorHandler : UniffiRustCallStatusErrorHandler<{{ class_name }}> {
+{{ visibility() }}object {{ class_name }}ErrorHandler : UniffiRustCallStatusErrorHandler<{{ class_name }}> {
     override fun lift(errorBuf: RustBufferByValue): {{ class_name }} = {{ package_name }}.{{ class_name }}ErrorHandler.lift(errorBuf.as{{ name }}())
 }
 

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/FfiConverterTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/FfiConverterTemplate.kt
@@ -1,13 +1,13 @@
 
-interface FfiConverter<KotlinType, FfiType> {
+{{ visibility() }}interface FfiConverter<KotlinType, FfiType> {
     // Convert an FFI type to a Kotlin type
-    fun lift(value: FfiType): KotlinType
+    {{ visibility() }}fun lift(value: FfiType): KotlinType
 
     // Convert an Kotlin type to an FFI type
-    fun lower(value: KotlinType): FfiType
+    {{ visibility() }}fun lower(value: KotlinType): FfiType
 
     // Read a Kotlin type from a `ByteBuffer`
-    fun read(buf: ByteBuffer): KotlinType
+    {{ visibility() }}fun read(buf: ByteBuffer): KotlinType
 
     // Calculate bytes to allocate when creating a `RustBuffer`
     //
@@ -17,10 +17,10 @@ interface FfiConverter<KotlinType, FfiType> {
     // encoding, so we pessimistically allocate the largest size possible (3
     // bytes per codepoint).  Allocating extra bytes is not really a big deal
     // because the `RustBuffer` is short-lived.
-    fun allocationSize(value: KotlinType): ULong
+    {{ visibility() }}fun allocationSize(value: KotlinType): ULong
 
     // Write a Kotlin type to a `ByteBuffer`
-    fun write(value: KotlinType, buf: ByteBuffer)
+    {{ visibility() }}fun write(value: KotlinType, buf: ByteBuffer)
 
     // Lower a value into a `RustBuffer`
     //
@@ -28,7 +28,7 @@ interface FfiConverter<KotlinType, FfiType> {
     // FfiType.  It's used by the callback interface code.  Callback interface
     // returns are always serialized into a `RustBuffer` regardless of their
     // normal FFI type.
-    fun lowerIntoRustBuffer(value: KotlinType): RustBufferByValue {
+    {{ visibility() }}fun lowerIntoRustBuffer(value: KotlinType): RustBufferByValue {
         val rbuf = RustBufferHelper.allocValue(allocationSize(value))
         val bbuf = rbuf.asByteBuffer()!!
         write(value, bbuf)
@@ -43,7 +43,7 @@ interface FfiConverter<KotlinType, FfiType> {
     //
     // This here mostly because of the symmetry with `lowerIntoRustBuffer()`.
     // It's currently only used by the `FfiConverterRustBuffer` class below.
-    fun liftFromRustBuffer(rbuf: RustBufferByValue): KotlinType {
+    {{ visibility() }}fun liftFromRustBuffer(rbuf: RustBufferByValue): KotlinType {
         val byteBuf = rbuf.asByteBuffer()!!
         try {
            val item = read(byteBuf)
@@ -58,7 +58,7 @@ interface FfiConverter<KotlinType, FfiType> {
 }
 
 // FfiConverter that uses `RustBuffer` as the FfiType
-interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBufferByValue> {
-    override fun lift(value: RustBufferByValue) = liftFromRustBuffer(value)
-    override fun lower(value: KotlinType) = lowerIntoRustBuffer(value)
+{{ visibility() }}interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBufferByValue> {
+    override fun lift(value: RustBufferByValue): KotlinType = liftFromRustBuffer(value)
+    override fun lower(value: KotlinType): RustBufferByValue = lowerIntoRustBuffer(value)
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Float32Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Float32Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterFloat: FfiConverter<Float, Float> {
+{{ visibility() }}object FfiConverterFloat: FfiConverter<Float, Float> {
     override fun lift(value: Float): Float {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterFloat: FfiConverter<Float, Float> {
         return value
     }
 
-    override fun allocationSize(value: Float) = 4UL
+    override fun allocationSize(value: Float): ULong = 4UL
 
     override fun write(value: Float, buf: ByteBuffer) {
         buf.putFloat(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Float64Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Float64Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterDouble: FfiConverter<Double, Double> {
+{{ visibility() }}object FfiConverterDouble: FfiConverter<Double, Double> {
     override fun lift(value: Double): Double {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterDouble: FfiConverter<Double, Double> {
         return value
     }
 
-    override fun allocationSize(value: Double) = 8UL
+    override fun allocationSize(value: Double): ULong = 8UL
 
     override fun write(value: Double, buf: ByteBuffer) {
         buf.putDouble(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Helpers.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Helpers.kt
@@ -23,8 +23,8 @@ internal fun UniffiRustCallStatusByValue.isPanic(): Boolean
     = code == UNIFFI_CALL_UNEXPECTED_ERROR
 
 // Each top-level error class has a companion object that can lift the error from the call status's rust buffer
-interface UniffiRustCallStatusErrorHandler<E> {
-    fun lift(errorBuf: RustBufferByValue): E
+{{ visibility() }}interface UniffiRustCallStatusErrorHandler<E> {
+    {{ visibility() }}fun lift(errorBuf: RustBufferByValue): E
 }
 
 // Helpers for calling Rust
@@ -61,7 +61,7 @@ internal fun<E: kotlin.Exception> uniffiCheckCallStatus(errorHandler: UniffiRust
 }
 
 // UniffiRustCallStatusErrorHandler implementation for times when we don't expect a CALL_ERROR
-object UniffiNullRustCallStatusErrorHandler: UniffiRustCallStatusErrorHandler<InternalException> {
+{{ visibility() }}object UniffiNullRustCallStatusErrorHandler: UniffiRustCallStatusErrorHandler<InternalException> {
     override fun lift(errorBuf: RustBufferByValue): InternalException {
         RustBufferHelper.free(errorBuf)
         return InternalException("Unexpected CALL_ERROR")

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Int16Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Int16Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterShort: FfiConverter<Short, Short> {
+{{ visibility() }}object FfiConverterShort: FfiConverter<Short, Short> {
     override fun lift(value: Short): Short {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterShort: FfiConverter<Short, Short> {
         return value
     }
 
-    override fun allocationSize(value: Short) = 2UL
+    override fun allocationSize(value: Short): ULong = 2UL
 
     override fun write(value: Short, buf: ByteBuffer) {
         buf.putShort(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Int32Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Int32Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterInt: FfiConverter<Int, Int> {
+{{ visibility() }}object FfiConverterInt: FfiConverter<Int, Int> {
     override fun lift(value: Int): Int {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterInt: FfiConverter<Int, Int> {
         return value
     }
 
-    override fun allocationSize(value: Int) = 4UL
+    override fun allocationSize(value: Int): ULong = 4UL
 
     override fun write(value: Int, buf: ByteBuffer) {
         buf.putInt(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Int64Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Int64Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterLong: FfiConverter<Long, Long> {
+{{ visibility() }}object FfiConverterLong: FfiConverter<Long, Long> {
     override fun lift(value: Long): Long {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterLong: FfiConverter<Long, Long> {
         return value
     }
 
-    override fun allocationSize(value: Long) = 8UL
+    override fun allocationSize(value: Long): ULong = 8UL
 
     override fun write(value: Long, buf: ByteBuffer) {
         buf.putLong(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/Int8Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/Int8Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterByte: FfiConverter<Byte, Byte> {
+{{ visibility() }}object FfiConverterByte: FfiConverter<Byte, Byte> {
     override fun lift(value: Byte): Byte {
         return value
     }
@@ -12,7 +12,7 @@ object FfiConverterByte: FfiConverter<Byte, Byte> {
         return value
     }
 
-    override fun allocationSize(value: Byte) = 1UL
+    override fun allocationSize(value: Byte): ULong = 1UL
 
     override fun write(value: Byte, buf: ByteBuffer) {
         buf.put(value)

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/MapTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/MapTemplate.kt
@@ -1,7 +1,7 @@
 
 {%- let key_type_name = key_type|type_name(ci) %}
 {%- let value_type_name = value_type|type_name(ci) %}
-object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
+{{ visibility() }}object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
     override fun read(buf: ByteBuffer): Map<{{ key_type_name }}, {{ value_type_name }}> {
         val len = buf.getInt()
         return buildMap<{{ key_type_name }}, {{ value_type_name }}>(len) {

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/ObjectCleanerHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/ObjectCleanerHelper.kt
@@ -5,12 +5,12 @@
 // The cleaner registers disposables and returns cleanables, so now we are
 // defining a `UniffiCleaner` with a `UniffiClenaer.Cleanable` to abstract the
 // different implementations available at compile time.
-interface UniffiCleaner {
-    interface Cleanable {
-        fun clean()
+{{ visibility() }}interface UniffiCleaner {
+    {{ visibility() }}interface Cleanable {
+        {{ visibility() }}fun clean()
     }
 
-    fun register(resource: Any, disposable: Disposable): UniffiCleaner.Cleanable
+    {{ visibility() }}fun register(resource: Any, disposable: Disposable): UniffiCleaner.Cleanable
 
-    companion object
+    {{ visibility() }}companion object
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/OptionalTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/OptionalTemplate.kt
@@ -1,7 +1,7 @@
 
 {%- let inner_type_name = inner_type|type_name(ci) %}
 
-object {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}?> {
+{{ visibility() }}object {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}?> {
     override fun read(buf: ByteBuffer): {{ inner_type_name }}? {
         if (buf.get().toInt() == 0) {
             return null

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/RecordTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/RecordTemplate.kt
@@ -1,7 +1,7 @@
 
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 
-object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
+{{ visibility() }}object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         {%- if rec.has_fields() %}
         return {{ type_name }}(
@@ -14,7 +14,7 @@ object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
         {%- endif %}
     }
 
-    override fun allocationSize(value: {{ type_name }}) = {%- if rec.has_fields() %} (
+    override fun allocationSize(value: {{ type_name }}): ULong = {%- if rec.has_fields() %} (
         {%- for field in rec.fields() %}
             {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }}){% if !loop.last %} +{% endif %}
         {%- endfor %}

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/RustBufferTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/RustBufferTemplate.kt
@@ -1,11 +1,11 @@
-fun RustBuffer.setValue(array: RustBufferByValue) {
+{{ visibility() }}fun RustBuffer.setValue(array: RustBufferByValue) {
     this.data = array.data
     this.len = array.len
     this.capacity = array.capacity
 }
 
 internal object RustBufferHelper {
-    fun allocValue(size: ULong = 0UL): RustBufferByValue = uniffiRustCall { status ->
+    internal fun allocValue(size: ULong = 0UL): RustBufferByValue = uniffiRustCall { status ->
         // Note: need to convert the size to a `Long` value to make this work with JVM.
         UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size.toLong(), status)
     }.also {
@@ -14,7 +14,7 @@ internal object RustBufferHelper {
         }
     }
 
-    fun free(buf: RustBufferByValue) = uniffiRustCall { status ->
+    internal fun free(buf: RustBufferByValue) = uniffiRustCall { status ->
         UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
     }
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/SequenceTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/SequenceTemplate.kt
@@ -1,7 +1,7 @@
 
 {%- let inner_type_name = inner_type|type_name(ci) %}
 
-object {{ ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_type_name }}>> {
+{{ visibility() }}object {{ ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_type_name }}>> {
     override fun read(buf: ByteBuffer): List<{{ inner_type_name }}> {
         val len = buf.getInt()
         return List<{{ inner_type_name }}>(len) {

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
@@ -1,7 +1,7 @@
 
 {{ self.add_import("okio.utf8Size") }}
 
-object FfiConverterString: FfiConverter<String, RustBufferByValue> {
+{{ visibility() }}object FfiConverterString: FfiConverter<String, RustBufferByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
     // store our length and avoid writing it out to the buffer.

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/TimestampHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/TimestampHelper.kt
@@ -1,5 +1,5 @@
 
-internal object FfiConverterTimestamp: FfiConverterRustBuffer<kotlinx.datetime.Instant> {
+{{ visibility() }}object FfiConverterTimestamp: FfiConverterRustBuffer<kotlinx.datetime.Instant> {
     override fun read(buf: ByteBuffer): kotlinx.datetime.Instant {
         val seconds = buf.getLong()
         val nanoseconds = buf.getInt()
@@ -16,7 +16,7 @@ internal object FfiConverterTimestamp: FfiConverterRustBuffer<kotlinx.datetime.I
     }
 
     // 8 bytes for seconds, 4 bytes for nanoseconds
-    override fun allocationSize(value: kotlinx.datetime.Instant) = 12UL
+    override fun allocationSize(value: kotlinx.datetime.Instant): ULong = 12UL
 
     override fun write(value: kotlinx.datetime.Instant, buf: ByteBuffer) {
         if (value.nanosecondsOfSecond < 0) {

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt16Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt16Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterUShort: FfiConverter<UShort, Short> {
+{{ visibility() }}object FfiConverterUShort: FfiConverter<UShort, Short> {
     override fun lift(value: Short): UShort {
         return value.toUShort()
     }
@@ -12,7 +12,7 @@ object FfiConverterUShort: FfiConverter<UShort, Short> {
         return value.toShort()
     }
 
-    override fun allocationSize(value: UShort) = 2UL
+    override fun allocationSize(value: UShort): ULong = 2UL
 
     override fun write(value: UShort, buf: ByteBuffer) {
         buf.putShort(value.toShort())

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt32Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt32Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterUInt: FfiConverter<UInt, Int> {
+{{ visibility() }}object FfiConverterUInt: FfiConverter<UInt, Int> {
     override fun lift(value: Int): UInt {
         return value.toUInt()
     }
@@ -12,7 +12,7 @@ object FfiConverterUInt: FfiConverter<UInt, Int> {
         return value.toInt()
     }
 
-    override fun allocationSize(value: UInt) = 4UL
+    override fun allocationSize(value: UInt): ULong = 4UL
 
     override fun write(value: UInt, buf: ByteBuffer) {
         buf.putInt(value.toInt())

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt64Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt64Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterULong: FfiConverter<ULong, Long> {
+{{ visibility() }}object FfiConverterULong: FfiConverter<ULong, Long> {
     override fun lift(value: Long): ULong {
         return value.toULong()
     }
@@ -12,7 +12,7 @@ object FfiConverterULong: FfiConverter<ULong, Long> {
         return value.toLong()
     }
 
-    override fun allocationSize(value: ULong) = 8UL
+    override fun allocationSize(value: ULong): ULong = 8UL
 
     override fun write(value: ULong, buf: ByteBuffer) {
         buf.putLong(value.toLong())

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt8Helper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/UInt8Helper.kt
@@ -1,5 +1,5 @@
 
-object FfiConverterUByte: FfiConverter<UByte, Byte> {
+{{ visibility() }}object FfiConverterUByte: FfiConverter<UByte, Byte> {
     override fun lift(value: Byte): UByte {
         return value.toUByte()
     }
@@ -12,7 +12,7 @@ object FfiConverterUByte: FfiConverter<UByte, Byte> {
         return value.toByte()
     }
 
-    override fun allocationSize(value: UByte) = 1UL
+    override fun allocationSize(value: UByte): ULong = 1UL
 
     override fun write(value: UByte, buf: ByteBuffer) {
         buf.put(value.toByte())

--- a/crates/gobley-uniffi-bindgen/src/templates/macros.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/macros.kt
@@ -54,7 +54,7 @@
 {{ " "|repeat(indent) }}@Throws({{ throwable|type_name(ci) }}::class {%- if callable.is_async() -%}, kotlin.coroutines.cancellation.CancellationException::class{%- endif -%})
                         {%-     else -%}
                         {%- endmatch %}
-{{ " "|repeat(indent) }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
+{{ " "|repeat(indent) }}{{ visibility() }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
                         {%- if callable.is_async() -%}suspend {% endif -%}
                         fun {{ callable.name()|fn_name }}(
                             {%- call arg_list(callable, is_decl_override || !callable.takes_self()) -%}
@@ -72,7 +72,7 @@
 {{ " "|repeat(indent) }}@Throws({{ throwable|type_name(ci) }}::class {%- if callable.is_async() -%}, kotlin.coroutines.cancellation.CancellationException::class{%- endif -%})
                         {%-     else -%}
                         {%- endmatch %}
-{{ " "|repeat(indent) }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
+{{ " "|repeat(indent) }}{{ visibility() }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
                         {%- if callable.is_async() -%}suspend {% endif -%}
                         fun {{ callable.name()|fn_name }}(
                             {%- call arg_list(callable, false) -%}
@@ -96,7 +96,7 @@
 
 {%- macro func_decl_with_stub(func_decl, callable, indent) %}
                         {%- call docstring(callable, indent) %}
-{{ " "|repeat(indent) }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
+{{ " "|repeat(indent) }}{{ visibility() }}{% if func_decl.len() != 0 -%}{{ func_decl }} {% endif -%}
                         {%- if callable.is_async() -%}suspend {% endif -%}
                         fun {{ callable.name()|fn_name }}(
                             {%- call arg_list(callable, false) -%}

--- a/crates/gobley-uniffi-bindgen/src/templates/native/Async.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/Async.kt
@@ -1,12 +1,12 @@
 {% include "ffi/Async.kt" %}
 
-val uniffiRustFutureContinuationCallbackCallback = staticCFunction { handle: Long, pollResult: Byte ->
+internal val uniffiRustFutureContinuationCallbackCallback = staticCFunction { handle: Long, pollResult: Byte ->
     uniffiContinuationHandleMap.remove(handle).resume(pollResult)
 }
 
 {%- if ci.has_async_callback_interface_definition() %}
 
-val uniffiForeignFutureFreeImpl = staticCFunction { handle: Long ->
+internal val uniffiForeignFutureFreeImpl = staticCFunction { handle: Long ->
     val job = uniffiForeignFutureHandleMap.remove(handle)
     if (!job.isCompleted) {
         job.cancel()

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
@@ -1,12 +1,12 @@
 
-class ByteBuffer(
+{{ visibility() }}class ByteBuffer(
     internal val pointer: CPointer<kotlinx.cinterop.ByteVar>,
     internal val capacity: Int,
     internal var position: Int = 0,
 ) {
-    fun position() = position
+    {{ visibility() }}fun position(): Int = position
 
-    fun hasRemaining() = capacity != position
+    {{ visibility() }}fun hasRemaining(): Boolean = capacity != position
 
     private fun checkRemaining(bytes: Int) {
         val remaining = capacity - position
@@ -15,12 +15,12 @@ class ByteBuffer(
         }
     }
 
-    fun get(): Byte {
+    {{ visibility() }}fun get(): Byte {
         checkRemaining(1)
         return pointer[position++]
     }
 
-    fun get(bytesToRead: Int): ByteArray {
+    {{ visibility() }}fun get(bytesToRead: Int): ByteArray {
         checkRemaining(bytesToRead)
         val result = ByteArray(bytesToRead)
         if (result.isNotEmpty()) {
@@ -32,13 +32,13 @@ class ByteBuffer(
         return result
     }
 
-    fun getShort(): Short {
+    {{ visibility() }}fun getShort(): Short {
         checkRemaining(2)
         return (((pointer[position++].toInt() and 0xff) shl 8)
                 or (pointer[position++].toInt() and 0xff)).toShort()
     }
 
-    fun getInt(): Int {
+    {{ visibility() }}fun getInt(): Int {
         checkRemaining(4)
         return (((pointer[position++].toInt() and 0xff) shl 24)
                 or ((pointer[position++].toInt() and 0xff) shl 16)
@@ -46,7 +46,7 @@ class ByteBuffer(
                 or (pointer[position++].toInt() and 0xff))
     }
 
-    fun getLong(): Long {
+    {{ visibility() }}fun getLong(): Long {
         checkRemaining(8)
         return (((pointer[position++].toLong() and 0xffL) shl 56)
                 or ((pointer[position++].toLong() and 0xffL) shl 48)
@@ -58,18 +58,16 @@ class ByteBuffer(
                 or (pointer[position++].toLong() and 0xffL))
     }
 
-    fun getFloat() = Float.fromBits(getInt())
+    {{ visibility() }}fun getFloat(): Float = Float.fromBits(getInt())
 
-    fun getDouble() = Double.fromBits(getLong())
+    {{ visibility() }}fun getDouble(): Double = Double.fromBits(getLong())
 
-
-
-    fun put(value: Byte) {
+    {{ visibility() }}fun put(value: Byte) {
         checkRemaining(1)
         pointer[position++] = value
     }
 
-    fun put(src: ByteArray) {
+    {{ visibility() }}fun put(src: ByteArray) {
         checkRemaining(src.size)
         if (src.isNotEmpty()) {
             src.usePinned { pinned ->
@@ -79,13 +77,13 @@ class ByteBuffer(
         }
     }
 
-    fun putShort(value: Short) {
+    {{ visibility() }}fun putShort(value: Short) {
         checkRemaining(2)
         pointer[position++] = (value.toInt() ushr 8 and 0xff).toByte()
         pointer[position++] = (value.toInt() and 0xff).toByte()
     }
 
-    fun putInt(value: Int) {
+    {{ visibility() }}fun putInt(value: Int) {
         checkRemaining(4)
         pointer[position++] = (value ushr 24 and 0xff).toByte()
         pointer[position++] = (value ushr 16 and 0xff).toByte()
@@ -93,7 +91,7 @@ class ByteBuffer(
         pointer[position++] = (value and 0xff).toByte()
     }
 
-    fun putLong(value: Long) {
+    {{ visibility() }}fun putLong(value: Long) {
         checkRemaining(8)
         pointer[position++] = (value ushr 56 and 0xffL).toByte()
         pointer[position++] = (value ushr 48 and 0xffL).toByte()
@@ -105,12 +103,11 @@ class ByteBuffer(
         pointer[position++] = (value and 0xffL).toByte()
     }
 
-    fun putFloat(value: Float) = putInt(value.toRawBits())
+    {{ visibility() }}fun putFloat(value: Float): Unit = putInt(value.toRawBits())
 
-    fun putDouble(value: Double) = putLong(value.toRawBits())
+    {{ visibility() }}fun putDouble(value: Double): Unit = putLong(value.toRawBits())
 
-
-    fun writeUtf8(value: String) {
+    {{ visibility() }}fun writeUtf8(value: String) {
         // TODO: prevent allocating a new byte array here
         put(value.encodeToByteArray())
     }

--- a/crates/gobley-uniffi-bindgen/src/templates/native/CallbackInterfaceTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/CallbackInterfaceTemplate.kt
@@ -9,4 +9,4 @@
 
 {% include "CallbackInterfaceImpl.kt" %}
 
-object {{ ffi_converter_name }} : FfiConverterCallbackInterface<{{ interface_name }}>()
+{{ visibility() }}object {{ ffi_converter_name }} : FfiConverterCallbackInterface<{{ interface_name }}>()

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ExternalTypeTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ExternalTypeTemplate.kt
@@ -21,7 +21,7 @@
 {{ self.add_import_as(fully_qualified_rustbuffer_name, local_rustbuffer_name) }}
 {{ self.add_import_as(fully_qualified_rustbuffer_by_value_name, local_rustbuffer_by_value_name) }}
 
-fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
+internal fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
     return {{ local_rustbuffer_by_value_name }}(
         capacity = capacity,
         len = len,
@@ -29,7 +29,7 @@ fun RustBufferByValue.as{{ name }}(): {{ local_rustbuffer_by_value_name }} {
     )
 }
 
-fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByValue {
+internal fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByValue {
     return RustBufferByValue(
         capacity = capacity,
         len = len,
@@ -37,7 +37,7 @@ fun {{ local_rustbuffer_by_value_name }}.from{{ name }}ToLocal(): RustBufferByVa
     )
 }
 
-fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{ name|class_name(ci) }} {
+internal fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{ name|class_name(ci) }} {
     val externalBuffer = {{ package_name }}.ByteBuffer(
         pointer = buf.pointer,
         capacity = buf.capacity,
@@ -48,7 +48,7 @@ fun {{ fully_qualified_ffi_converter_name }}.read{{ name }}(buf: ByteBuffer): {{
     return result
 }
 
-fun {{ fully_qualified_ffi_converter_name }}.write{{ name }}(value: {{ name|class_name(ci) }}, buf: ByteBuffer) {
+internal fun {{ fully_qualified_ffi_converter_name }}.write{{ name }}(value: {{ name|class_name(ci) }}, buf: ByteBuffer) {
     val externalBuffer = {{ package_name }}.ByteBuffer(
         pointer = buf.pointer,
         capacity = buf.capacity,

--- a/crates/gobley-uniffi-bindgen/src/templates/native/HandleMap.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/HandleMap.kt
@@ -6,27 +6,27 @@ internal class UniffiHandleMap<T: Any> {
     // We'll start at 1L to prevent "Null Pointers" in native's `interpretCPointer`
     private val counter: kotlinx.atomicfu.AtomicLong = kotlinx.atomicfu.atomic(1L)
 
-    val size: Int
+    internal val size: Int
         get() = map.size
 
     // Insert a new object into the handle map and get a handle for it
-    fun insert(obj: T): Long {
+    internal fun insert(obj: T): Long {
         val handle = counter.getAndAdd(1)
         syncAccess { map.put(handle, obj) }
         return handle
     }
 
     // Get an object from the handle map
-    fun get(handle: Long): T {
+    internal fun get(handle: Long): T {
         return syncAccess { map.get(handle) } ?: throw InternalException("UniffiHandleMap.get: Invalid handle")
     }
 
     // Remove an entry from the handlemap and get the Kotlin object back
-    fun remove(handle: Long): T {
+    internal fun remove(handle: Long): T {
         return syncAccess { map.remove(handle) } ?: throw InternalException("UniffiHandleMap.remove: Invalid handle")
     }
 
-    fun <T> syncAccess(block: () -> T): T {
+    internal fun <T> syncAccess(block: () -> T): T {
         mapLock.lock()
         try {
             return block()

--- a/crates/gobley-uniffi-bindgen/src/templates/native/Helpers.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/Helpers.kt
@@ -9,7 +9,7 @@ internal var UniffiRustCallStatus.errorBuf: RustBufferByValue
     set(value) { value.place(pointed.errorBuf.ptr) }
 
 internal typealias UniffiRustCallStatusByValue = CValue<{{ ci.namespace() }}.cinterop.UniffiRustCallStatus>
-fun UniffiRustCallStatusByValue(
+internal fun UniffiRustCallStatusByValue(
     code: Byte,
     errorBuf: RustBufferByValue
 ): UniffiRustCallStatusByValue {

--- a/crates/gobley-uniffi-bindgen/src/templates/native/NamespaceLibraryTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/NamespaceLibraryTemplate.kt
@@ -32,7 +32,7 @@ internal fun {{ ffi_struct.name()|ffi_struct_name }}.uniffiSetValue(other: {{ ff
 }
 
 internal typealias {{ ffi_struct.name()|ffi_struct_name }}UniffiByValue = CValue<{{ ci.namespace() }}.cinterop.{{ ffi_struct.name()|ffi_struct_name }}>
-fun {{ ffi_struct.name()|ffi_struct_name }}UniffiByValue(
+internal fun {{ ffi_struct.name()|ffi_struct_name }}UniffiByValue(
     {%- for field in ffi_struct.fields() %}
     {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }},
     {%- endfor %}
@@ -108,6 +108,6 @@ internal class UniffiLibInstance: UniffiLib {
     {% endfor %}
 }
 
-fun uniffiEnsureInitialized() {
+{{ visibility() }}fun uniffiEnsureInitialized() {
     UniffiLib.INSTANCE
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ReferenceHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ReferenceHelper.kt
@@ -1,56 +1,56 @@
 
-typealias ByteByReference = CPointer<ByteVar>
-fun ByteByReference.setValue(value: Byte) {
+internal typealias ByteByReference = CPointer<ByteVar>
+internal fun ByteByReference.setValue(value: Byte) {
     this.pointed.value = value
 }
-fun ByteByReference.getValue() : Byte {
+internal fun ByteByReference.getValue() : Byte {
     return this.pointed.value
 }
 
-typealias DoubleByReference = CPointer<DoubleVar>
-fun DoubleByReference.setValue(value: Double) {
+internal typealias DoubleByReference = CPointer<DoubleVar>
+internal fun DoubleByReference.setValue(value: Double) {
     this.pointed.value = value
 }
-fun DoubleByReference.getValue() : Double {
+internal fun DoubleByReference.getValue() : Double {
     return this.pointed.value
 }
 
-typealias FloatByReference = CPointer<FloatVar>
-fun FloatByReference.setValue(value: Float) {
+internal typealias FloatByReference = CPointer<FloatVar>
+internal fun FloatByReference.setValue(value: Float) {
     this.pointed.value = value
 }
-fun FloatByReference.getValue() : Float {
+internal fun FloatByReference.getValue() : Float {
     return this.pointed.value
 }
 
-typealias IntByReference = CPointer<IntVar>
-fun IntByReference.setValue(value: Int) {
+internal typealias IntByReference = CPointer<IntVar>
+internal fun IntByReference.setValue(value: Int) {
     this.pointed.value = value
 }
-fun IntByReference.getValue() : Int {
+internal fun IntByReference.getValue() : Int {
     return this.pointed.value
 }
 
-typealias LongByReference = CPointer<LongVar>
-fun LongByReference.setValue(value: Long) {
+internal typealias LongByReference = CPointer<LongVar>
+internal fun LongByReference.setValue(value: Long) {
     this.pointed.value = value
 }
-fun LongByReference.getValue() : Long {
+internal fun LongByReference.getValue() : Long {
     return this.pointed.value
 }
 
-typealias PointerByReference = CPointer<COpaquePointerVar>
-fun PointerByReference.setValue(value: Pointer?) {
+internal typealias PointerByReference = CPointer<COpaquePointerVar>
+internal fun PointerByReference.setValue(value: Pointer?) {
     this.pointed.value = value
 }
-fun PointerByReference.getValue(): Pointer? {
+internal fun PointerByReference.getValue(): Pointer? {
     return this.pointed.value
 }
 
-typealias ShortByReference = CPointer<ShortVar>
-fun ShortByReference.setValue(value: Short) {
+internal typealias ShortByReference = CPointer<ShortVar>
+internal fun ShortByReference.setValue(value: Short) {
     this.pointed.value = value
 }
-fun ShortByReference.getValue(): Short {
+internal fun ShortByReference.getValue(): Short {
     return this.pointed.value
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/native/RustBufferTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/RustBufferTemplate.kt
@@ -1,17 +1,17 @@
 {% include "ffi/RustBufferTemplate.kt" %}
 
-typealias RustBuffer = CPointer<{{ ci.namespace() }}.cinterop.RustBuffer>
+{{ visibility() }}typealias RustBuffer = CPointer<{{ ci.namespace() }}.cinterop.RustBuffer>
 
-var RustBuffer.capacity: Long
+{{ visibility() }}var RustBuffer.capacity: Long
     get() = pointed.capacity
     set(value) { pointed.capacity = value }
-var RustBuffer.len: Long
+{{ visibility() }}var RustBuffer.len: Long
     get() = pointed.len
     set(value) { pointed.len = value }
-var RustBuffer.data: Pointer?
+{{ visibility() }}var RustBuffer.data: Pointer?
     get() = pointed.data
     set(value) { pointed.data = value?.reinterpret() }
-fun RustBuffer.asByteBuffer(): ByteBuffer? {
+{{ visibility() }}fun RustBuffer.asByteBuffer(): ByteBuffer? {
     {% call kt::check_rust_buffer_length("pointed.len") %}
     return ByteBuffer(
         pointed.data?.reinterpret<kotlinx.cinterop.ByteVar>() ?: return null,
@@ -19,8 +19,8 @@ fun RustBuffer.asByteBuffer(): ByteBuffer? {
     )
 }
 
-typealias RustBufferByValue = CValue<{{ ci.namespace() }}.cinterop.RustBuffer>
-fun RustBufferByValue(
+{{ visibility() }}typealias RustBufferByValue = CValue<{{ ci.namespace() }}.cinterop.RustBuffer>
+{{ visibility() }}fun RustBufferByValue(
     capacity: Long,
     len: Long,
     data: Pointer?,
@@ -31,13 +31,13 @@ fun RustBufferByValue(
         this.data = data?.reinterpret()
     }
 }
-val RustBufferByValue.capacity: Long
+{{ visibility() }}val RustBufferByValue.capacity: Long
     get() = useContents { capacity }
-val RustBufferByValue.len: Long
+{{ visibility() }}val RustBufferByValue.len: Long
     get() = useContents { len }
-val RustBufferByValue.data: Pointer?
+{{ visibility() }}val RustBufferByValue.data: Pointer?
     get() = useContents { data }
-fun RustBufferByValue.asByteBuffer(): ByteBuffer? {
+{{ visibility() }}fun RustBufferByValue.asByteBuffer(): ByteBuffer? {
     {% call kt::check_rust_buffer_length("len") %}
     return ByteBuffer(
         data?.reinterpret<kotlinx.cinterop.ByteVar>() ?: return null,

--- a/crates/gobley-uniffi-bindgen/src/templates/stub/ObjectTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/stub/ObjectTemplate.kt
@@ -9,9 +9,9 @@
 
 {%- call kt::docstring(obj, 0) %}
 {% if (is_error) %}
-actual open class {{ impl_class_name }} : kotlin.Exception, Disposable, {{ interface_name }} {
+{{ visibility() }}actual open class {{ impl_class_name }} : kotlin.Exception, Disposable, {{ interface_name }} {
 {% else -%}
-actual open class {{ impl_class_name }}: Disposable, {{ interface_name }}
+{{ visibility() }}actual open class {{ impl_class_name }}: Disposable, {{ interface_name }}
 {%- for t in obj.trait_impls() -%}
 , {{ self::trait_interface_name(ci, t.trait_name)? }}
 {%- endfor %} {
@@ -22,7 +22,7 @@ actual open class {{ impl_class_name }}: Disposable, {{ interface_name }}
      * attempt to actually use an object constructed this way will fail as there is no
      * connected Rust object.
      */
-    actual constructor(noPointer: NoPointer)
+    {{ visibility() }}actual constructor(noPointer: NoPointer)
 
     {%- match obj.primary_constructor() %}
     {%- when Some(cons) %}
@@ -31,7 +31,7 @@ actual open class {{ impl_class_name }}: Disposable, {{ interface_name }}
     {%-     else %}
     {%- call kt::docstring(cons, 4) %}
 
-    actual constructor({% call kt::arg_list(cons, false) -%}) {
+    {{ visibility() }}actual constructor({% call kt::arg_list(cons, false) -%}) {
         TODO()
     }
     {%-     endif %}
@@ -71,12 +71,12 @@ actual open class {{ impl_class_name }}: Disposable, {{ interface_name }}
 
     {# XXX - "companion object" confusion? How to have alternate constructors *and* be an error? #}
     {% if !obj.alternate_constructors().is_empty() -%}
-    actual companion object {
+    {{ visibility() }}actual companion object {
         {% for cons in obj.alternate_constructors() -%}
         {%- call kt::func_decl_with_stub("actual", cons, 8) %}
         {% endfor %}
     }
     {% else %}
-    actual companion object
+    {{ visibility() }}actual companion object
     {% endif %}
 }

--- a/tests/uniffi/coverall-android/build.gradle.kts
+++ b/tests/uniffi/coverall-android/build.gradle.kts
@@ -17,6 +17,7 @@ uniffi {
 }
 
 kotlin {
+    explicitApi()
     compilerOptions {
         jvmTarget = JvmTarget.JVM_17
     }

--- a/tests/uniffi/coverall-jvm/build.gradle.kts
+++ b/tests/uniffi/coverall-jvm/build.gradle.kts
@@ -24,6 +24,7 @@ uniffi {
 }
 
 kotlin {
+    explicitApi()
     compilerOptions {
         jvmTarget = JvmTarget.JVM_17
     }

--- a/tests/uniffi/coverall-pure-kotlin-dep/build.gradle.kts
+++ b/tests/uniffi/coverall-pure-kotlin-dep/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
     jvmToolchain(17)
     jvm()
     hostNativeTarget {

--- a/tests/uniffi/coverall-pure-kotlin-dep/src/commonMain/kotlin/PureKotlinLibrary.kt
+++ b/tests/uniffi/coverall-pure-kotlin-dep/src/commonMain/kotlin/PureKotlinLibrary.kt
@@ -4,6 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-object PureKotlinLibrary {
-    fun add(lhs: Int, rhs: Int) = lhs + rhs
+public object PureKotlinLibrary {
+    public fun add(lhs: Int, rhs: Int): Int = lhs + rhs
 }


### PR DESCRIPTION
## Changes

- Added an internal type, `Visibility` to the bindgen. This type will be public in 0.4.0, with another PR for #19.
- Made the bindgen render explicit visibility modifiers based on the value set in `gen_kotlin_multiplatform/mod.rs`.

## Testing

- Added `explicitApi()` to `build.gradle.kts` files of the UniFFI tests.

## Issues Fixed

Fixes: #163
