### PR TITLE
Delete the dependency on Okio

### DIFF
--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -427,9 +427,6 @@ class UniFfiPlugin : Plugin<Project> {
             }
             if (uniFfiExtension.addDependencies.get()) {
                 dependencies {
-                    implementation("com.squareup.okio:okio") {
-                        version { prefer(DependencyVersions.OKIO) }
-                    }
                     implementation("org.jetbrains.kotlinx:atomicfu") {
                         version { prefer(DependencyVersions.KOTLINX_ATOMICFU) }
                     }

--- a/build-logic/gobley-gradle/build.gradle.kts
+++ b/build-logic/gobley-gradle/build.gradle.kts
@@ -62,7 +62,6 @@ buildConfig {
     buildConfigField("String", "WASM_TRANSFORMER_BIN", "\"${wasmTransformerManifest.firstBinaryName}\"")
 
     forClass("DependencyVersions") {
-        buildConfigField("String", "OKIO", "\"${libs.versions.okio.get()}\"")
         buildConfigField("String", "KOTLINX_ATOMICFU", "\"${libs.versions.kotlinx.atomicfu.get()}\"")
         buildConfigField("String", "KOTLINX_DATETIME", "\"${libs.versions.kotlinx.datetime.get()}\"")
         buildConfigField("String", "KOTLINX_COROUTINES", "\"${libs.versions.kotlinx.coroutines.get()}\"")

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/ByteBuffer.kt
@@ -54,11 +54,4 @@
     {{ visibility() }}fun putDouble(value: Double) {
         inner.putDouble(value)
     }
-
-    {{ visibility() }}fun writeUtf8(value: String) {
-        Charsets.UTF_8.newEncoder().run {
-            onMalformedInput(java.nio.charset.CodingErrorAction.REPLACE)
-            encode(java.nio.CharBuffer.wrap(value), inner, false)
-        }
-    }
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
@@ -21,7 +21,7 @@
 
     override fun lower(value: String): RustBufferByValue {
         // TODO: prevent allocating a new byte array here
-        val encoded = value.encodeToByteArray()
+        val encoded = value.encodeToByteArray(throwOnInvalidSequence = true)
         return RustBufferHelper.allocValue(encoded.size.toULong()).apply {
             asByteBuffer()!!.put(encoded)
         }
@@ -38,7 +38,7 @@
 
     override fun write(value: String, buf: ByteBuffer) {
         // TODO: prevent allocating a new byte array here
-        val encoded = value.encodeToByteArray()
+        val encoded = value.encodeToByteArray(throwOnInvalidSequence = true)
         buf.putInt(encoded.size)
         buf.put(encoded)
     }

--- a/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/ffi/StringHelper.kt
@@ -1,6 +1,4 @@
 
-{{ self.add_import("okio.utf8Size") }}
-
 {{ visibility() }}object FfiConverterString: FfiConverter<String, RustBufferByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
@@ -22,8 +20,10 @@
     }
 
     override fun lower(value: String): RustBufferByValue {
-        return RustBufferHelper.allocValue(value.utf8Size().toULong()).apply {
-            asByteBuffer()!!.writeUtf8(value)
+        // TODO: prevent allocating a new byte array here
+        val encoded = value.encodeToByteArray()
+        return RustBufferHelper.allocValue(encoded.size.toULong()).apply {
+            asByteBuffer()!!.put(encoded)
         }
     }
 
@@ -37,7 +37,9 @@
     }
 
     override fun write(value: String, buf: ByteBuffer) {
-        buf.putInt(value.utf8Size().toInt())
-        buf.writeUtf8(value)
+        // TODO: prevent allocating a new byte array here
+        val encoded = value.encodeToByteArray()
+        buf.putInt(encoded.size)
+        buf.put(encoded)
     }
 }

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
@@ -106,9 +106,4 @@
     {{ visibility() }}fun putFloat(value: Float): Unit = putInt(value.toRawBits())
 
     {{ visibility() }}fun putDouble(value: Double): Unit = putLong(value.toRawBits())
-
-    {{ visibility() }}fun writeUtf8(value: String) {
-        // TODO: prevent allocating a new byte array here
-        put(value.encodeToByteArray())
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ androidx-test-runner = "1.6.2"
 jna = "5.17.0"
 junit = "4.13.2"
 ktor = "3.0.3"
-okio = "3.9.1"
 tomlkt = "0.3.7"
 semver = "2.0.0"
 
@@ -62,7 +61,6 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version.ref = "tomlkt" }
 semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 

--- a/tests/uniffi/type-limits/src/commonTest/kotlin/TypeLimitsTest.kt
+++ b/tests/uniffi/type-limits/src/commonTest/kotlin/TypeLimitsTest.kt
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.*
 import io.kotest.matchers.*
 import type_limits.*
 import kotlin.test.*
@@ -12,8 +12,11 @@ import kotlin.test.*
 class TypeLimitsTest {
     @Test
     fun testStringLimits() {
-        // TODO: Okio Buffer.writeUtf8 does not throw. See ByteBuffer.fromUtf8.
-        // takeString("\ud800")
+        // Kotlin Stdlib's String.encodeToByteArray() does not throw for invalid UTF-16 sequence.
+        // The replacement byte sequence to be used is platform-dependant.
+        // On JVM: 0x3F ('?') is used.
+        // On Koltin/Native: 0xEF, 0xBF, 0xBD is used. When decoded, this becomes 0xFFFD.
+        takeString("\ud800").shouldBeOneOf("?", "\uFFFD")
         takeString("") shouldBe ""
         takeString("愛") shouldBe "愛"
         takeString("💖") shouldBe "💖"

--- a/tests/uniffi/type-limits/src/commonTest/kotlin/TypeLimitsTest.kt
+++ b/tests/uniffi/type-limits/src/commonTest/kotlin/TypeLimitsTest.kt
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import io.kotest.matchers.collections.*
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.*
 import type_limits.*
 import kotlin.test.*
@@ -12,11 +12,9 @@ import kotlin.test.*
 class TypeLimitsTest {
     @Test
     fun testStringLimits() {
-        // Kotlin Stdlib's String.encodeToByteArray() does not throw for invalid UTF-16 sequence.
-        // The replacement byte sequence to be used is platform-dependant.
-        // On JVM: 0x3F ('?') is used.
-        // On Koltin/Native: 0xEF, 0xBF, 0xBD is used. When decoded, this becomes 0xFFFD.
-        takeString("\ud800").shouldBeOneOf("?", "\uFFFD")
+        shouldThrow<CharacterCodingException> {
+            takeString("\ud800")
+        }
         takeString("") shouldBe ""
         takeString("愛") shouldBe "愛"
         takeString("💖") shouldBe "💖"


### PR DESCRIPTION
## Changes

- Deleted the dependency on Okio from UniFFI projects.
- Replaced `ByteBuffer.writeUtf8` in the bindings with `String.encodeToByteArray(throwOnInvalidSequence = true)`. This allocates one more `ByteArray`, but it ensures that UniFFI functions always throw when given an invalid UTF-16 sequence. This is the same behavior as in upstream.

## Testing

- Added a test case with an invalid UTF-16 sequence to `:tests:uniffi:type-limits`.

## Issues Fixed

Fixes: #91
