### PR TITLE
Make CargoBuildTask print human-readable error messages

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoCheckTask.kt
@@ -52,7 +52,7 @@ abstract class CargoCheckTask : CargoPackageTask() {
             }
             suppressXcodeIosToolchains()
         }.get().apply {
-            assertNormalExitValue()
+            assertNormalExitValueUsingLogger()
         }
     }
 }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/RustUpTargetAddTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/RustUpTargetAddTask.kt
@@ -10,7 +10,6 @@ import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.rust.targets.RustTarget
 import gobley.gradle.tasks.GloballyLockedTask
 import gobley.gradle.tasks.globalLock
-import io.github.z4kn4fein.semver.Version
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -58,7 +57,7 @@ abstract class RustUpTargetAddTask : RustUpTask(), GloballyLockedTask {
             if (!isToolchainInstalled()) {
                 rustUp("target", "add", rustTarget.get().rustTriple)
                     .get().apply {
-                        assertNormalExitValue()
+                        assertNormalExitValueUsingLogger()
                     }
             }
         }

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/TransformWasmTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/TransformWasmTask.kt
@@ -64,7 +64,7 @@ abstract class TransformWasmTask : CommandTask() {
                 arguments("--function-imports-file", functionImportsFile.get())
             }
         }.get().apply {
-            assertNormalExitValue()
+            assertNormalExitValueUsingLogger()
         }
     }
 }


### PR DESCRIPTION
## Changes

- Added various logging options to `CommandResult.assertNormalExitValue`.
- Made the tasks pass `logger` to `CommandResult.assertNormalExitValue` by default.
- `CargoBuildTask` now prints the parsed errors using a logger, not dumping the JSONL retrieved from Cargo directly to stdout.

## Testing

| Before the change | After the change |
| ----------------- | ---------------- |
| <img width="2032" height="1111" alt="image" src="https://github.com/user-attachments/assets/bcddb7d0-3d63-433e-b1ca-bbec6e656675" /> | <img width="2032" height="1111" alt="image" src="https://github.com/user-attachments/assets/8a5a963d-50dd-46a9-85b6-71c682fbe930" /> |

## Issues Fixed

Fixes: #172
