### PR TITLE
Make CargoBuildTask replace backslashes in paths with slashes when rendering nativeStaticLibsDefFile

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoBuildTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoBuildTask.kt
@@ -91,8 +91,8 @@ abstract class CargoBuildTask : CargoPackageTask() {
                 if (message !is CargoMessage.CompilerMessage) {
                     continue
                 }
-                val renderedMessage =
-                    message.message.rendered?.trim()?.takeIf(String::isNotEmpty) ?: continue
+                val renderedMessage = message.message.rendered?.takeIf(String::isNotBlank)
+                    ?: continue
                 if (
                     arrayOf(
                         "note: Link against",


### PR DESCRIPTION
## Changes

- This PR fixes the bug introduced by #113. Cinterop considers backslashes to be escape sequences, even on Windows.
- Made `CargoBuildTask` replace backslashes in static library paths with slashes when rendering nativeStaticLibsDefFile.
- Made `CargoBuildTask` not log messages related to static library linking.

## Testing

- Fixed `:tests:gradle:cargo-only` failing on Windows since #113.
  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/20e5964b-a86b-4028-8054-e39b78f5f4b1" />

## Issues Fixed

Fixes: #173
