### PR TITLE
Remove "dev." from entry point names in :examples:app

### DIFF
--- a/examples/app/build.gradle.kts
+++ b/examples/app/build.gradle.kts
@@ -103,7 +103,7 @@ kotlin {
     //     linuxArm64(),
     // ).forEach {
     //     it.binaries.executable {
-    //         entryPoint = "dev.gobley.uniffi.examples.app.main"
+    //         entryPoint = "gobley.uniffi.examples.app.main"
     //     }
     //     it.compilations.getByName("main") {
     //         cinterops.register("gtk") {
@@ -119,7 +119,7 @@ kotlin {
             macosX64(),
         ).forEach {
             it.binaries.executable {
-                entryPoint = "dev.gobley.uniffi.examples.app.main"
+                entryPoint = "gobley.uniffi.examples.app.main"
             }
         }
 


### PR DESCRIPTION
A follow-up PR for #177. Removed the "dev." part in entry point names in `build.gradle.kts` of `:examples:app`.