### PR TITLE
Use `kotlinx.cinterop.convert` to cast `Int` to `size_t`

### DIFF
--- a/.github/workflows/pr-build-test-examples.ps1
+++ b/.github/workflows/pr-build-test-examples.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.uniffiTests=false";
 } finally {

--- a/.github/workflows/pr-build-test-gradle-tests.ps1
+++ b/.github/workflows/pr-build-test-gradle-tests.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.uniffiTests=false" `
         "-Pgobley.projects.examples=false";
 } finally {

--- a/.github/workflows/pr-build-test-uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test-uniffi-tests.ps1
@@ -2,22 +2,22 @@ $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
 try {
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.examples=false" `
         "-Pgobley.projects.uniffiTests.generateImmutableRecords=false" `
         "-Pgobley.projects.uniffiTests.omitChecksums=false";
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.examples=false" `
         "-Pgobley.projects.uniffiTests.generateImmutableRecords=true" `
         "-Pgobley.projects.uniffiTests.omitChecksums=false";
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.examples=false" `
         "-Pgobley.projects.uniffiTests.generateImmutableRecords=false" `
         "-Pgobley.projects.uniffiTests.omitChecksums=true";
-    ./gradlew check `
+    ./gradlew build `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.examples=false" `
         "-Pgobley.projects.uniffiTests.generateImmutableRecords=true" `

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
@@ -1,4 +1,3 @@
-{{- self.add_import("kotlinx.cinterop.convert") -}}
 
 {{ visibility() }}class ByteBuffer(
     internal val pointer: CPointer<kotlinx.cinterop.ByteVar>,

--- a/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/ByteBuffer.kt
@@ -1,3 +1,4 @@
+{{- self.add_import("kotlinx.cinterop.convert") -}}
 
 {{ visibility() }}class ByteBuffer(
     internal val pointer: CPointer<kotlinx.cinterop.ByteVar>,
@@ -25,7 +26,7 @@
         val result = ByteArray(bytesToRead)
         if (result.isNotEmpty()) {
             result.usePinned { pinned ->
-                memcpy(pinned.addressOf(0), pointer + position, bytesToRead.toULong())
+                memcpy(pinned.addressOf(0), pointer + position, bytesToRead.convert())
             }
             position += bytesToRead
         }
@@ -71,7 +72,7 @@
         checkRemaining(src.size)
         if (src.isNotEmpty()) {
             src.usePinned { pinned ->
-                memcpy(pointer + position, pinned.addressOf(0), src.size.toULong())
+                memcpy(pointer + position, pinned.addressOf(0), src.size.convert())
             }
             position += src.size
         }

--- a/crates/gobley-uniffi-bindgen/src/templates/native/wrapper.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/wrapper.kt
@@ -36,6 +36,7 @@ import kotlinx.cinterop.useContents
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.plus
 import kotlinx.cinterop.ptr

--- a/examples/app/build.gradle.kts
+++ b/examples/app/build.gradle.kts
@@ -46,7 +46,8 @@ kotlin {
     }
     arrayOf(
         androidNativeArm64(),
-        androidNativeArm32(),
+        // Konan has libunwind.a for Arm32
+        // androidNativeArm32(),
         androidNativeX64(),
         androidNativeX86(),
     ).forEach {

--- a/examples/app/build.gradle.kts
+++ b/examples/app/build.gradle.kts
@@ -44,49 +44,51 @@ kotlin {
             entryPoint = "gobley.uniffi.examples.app.main"
         }
     }
+
+    arrayOf(
+        androidNativeArm32()
+    ).forEach {
+        it.binaries.configureEach {
+             linkerOpts("-Wl,--allow-multiple-definition")
+//            linkerOpts(
+//                "-Wl,--exclude-libs,libunwind.a",
+//                "-Wl,--exclude-libs,libgcc.a",
+//                "-Wl,--exclude-libs,libgcc_real.a",
+//            )
+        }
+    }
+
     arrayOf(
         androidNativeArm64(),
-        // Konan has libunwind.a for Arm32
-        // androidNativeArm32(),
         androidNativeX64(),
         androidNativeX86(),
     ).forEach {
-        it.compilations.configureEach {
-            compileTaskProvider.configure {
-                val linkerFlagsArg = StringBuilder().apply {
-                    // Override Konan properties to link libunwind.a
-                    append("-Xoverride-konan-properties=linkerKonanFlags.")
-                    append(it.konanTarget.name)
-                    // Copied from https://github.com/JetBrains/kotlin/blob/6dff5659f42b0b90863d10ee503efd5a8ebb1034/kotlin-native/konan/konan.properties#L839
-                    append("=-lm -lc++_static -lc++abi -landroid -llog -latomic ")
-                    // Find the directory containing libunwind.a
-                    val ndkHostTag = when (GobleyHost.Platform.current) {
-                        GobleyHost.Platform.Windows -> "windows-x86_64"
-                        GobleyHost.Platform.MacOS -> "darwin-x86_64"
-                        GobleyHost.Platform.Linux -> "linux-x86_64"
-                    }
-                    val toolchainDir = android.ndkDirectory
-                        .resolve("toolchains/llvm/prebuilt")
-                        .resolve(ndkHostTag)
-                    val clangResourceDir = toolchainDir
-                        .resolve("lib/clang")
-                        .listFiles()
-                        ?.firstOrNull { file -> !file.name.startsWith(".") }
-                        ?: error("Couldn't find Clang resource directory")
-                    val clangRuntimeDir = clangResourceDir
-                        .resolve("lib/linux")
-                        .resolve(
-                            when (it.konanTarget.architecture) {
-                                Architecture.ARM64 -> "aarch64"
-                                Architecture.ARM32 -> "arm"
-                                Architecture.X64 -> "x86_64"
-                                Architecture.X86 -> "i386"
-                            }
-                        )
-                    append("-L${clangRuntimeDir.absolutePath}")
-                }.toString()
-                compilerOptions.freeCompilerArgs.add(linkerFlagsArg)
+        it.binaries.configureEach {
+            // Find the directory containing libunwind.a
+            val ndkHostTag = when (GobleyHost.Platform.current) {
+                GobleyHost.Platform.Windows -> "windows-x86_64"
+                GobleyHost.Platform.MacOS -> "darwin-x86_64"
+                GobleyHost.Platform.Linux -> "linux-x86_64"
             }
+            val toolchainDir = android.ndkDirectory
+                .resolve("toolchains/llvm/prebuilt")
+                .resolve(ndkHostTag)
+            val clangResourceDir = toolchainDir
+                .resolve("lib/clang")
+                .listFiles()
+                ?.firstOrNull { file -> !file.name.startsWith(".") }
+                ?: error("Couldn't find Clang resource directory")
+            val clangRuntimeDir = clangResourceDir
+                .resolve("lib/linux")
+                .resolve(
+                    when (it.konanTarget.architecture) {
+                        Architecture.ARM64 -> "aarch64"
+                        Architecture.ARM32 -> "arm"
+                        Architecture.X64 -> "x86_64"
+                        Architecture.X86 -> "i386"
+                    }
+                )
+            linkerOpts("-L${clangRuntimeDir.absolutePath}")
         }
     }
 

--- a/examples/app/build.gradle.kts
+++ b/examples/app/build.gradle.kts
@@ -50,9 +50,61 @@ kotlin {
     ).forEach {
         it.compilations.configureEach {
             compileTaskProvider.configure {
-                // Override Konan properties to make sure libgcc.a is mentioned before any other Rust static libraries
+                // Override Konan properties to make sure libgcc.a is mentioned before any other
+                // Rust static libraries to prevent "multiple definition of symbols" errors.
+                //
                 // The original linkerKonanFlags.android_arm32 is copied from:
                 // https://github.com/JetBrains/kotlin/blob/6dff5659f42b0b90863d10ee503efd5a8ebb1034/kotlin-native/konan/konan.properties#L839
+                //
+                // By default, the Rust compiler automatically injects the `compiler_builtins` crate
+                // during build, even when `#![no_std]` is enabled. Like the `core`, `alloc`, or
+                // `std` crates, object files from `compiler_builtins` will be included in static
+                // libraries built with the `staticlib` crate type.
+                //
+                // `compiler_builtins` contains routines that can't be replaced with few
+                // instructions on the target hardware, such as float-to-int conversion on ARM32.
+                // This crate also contains its own implementation of `memcpy` or `strlen` for
+                // platforms where `libc` is unavailable, as calling `memcpy` is the current
+                // implementation of Rust's move semantics.
+                //
+                // `compiler_builtins` is actually a port of LLVM's compiler runtime library,
+                // `compiler-rt`. When Clang compiles C/C++ code, it tries to link
+                // `libclang_rt.builtins*.a`, which is the pre-built runtime library that Clang
+                // uses. GCC has its own compiler runtime library, `libgcc`, as well. These three
+                // libraries share almost the same functions, such as `__fixunsdfdi` or
+                // `__sync_fetch_and_add_<N>`.
+                //
+                // Clang allows using `libgcc` instead of `compiler-rt` using the `--rtlib=`
+                // compiler flag. Using this compatibility, the NDK had completely migrated from
+                // using `libgcc` to `libunwind` and `libclang_rt` in r23. Rust 1.67 and older
+                // versions also had used `libgcc` on Android, but as Rust 1.68 started to target
+                // NDK r25, it now uses `libunwind` and `compiler_builtins`.
+                //
+                // However, the Konan dependencies shipped with Kotlin/Native 2.1.10 still contains
+                // `libgcc`, and Kotlin/Native depends on it. When Kotlin/Native 2.1.10 links a Rust
+                // static library to a Kotlin executable, it tries to mix `libgcc` and
+                // `compiler_builtins`. Starting from Rust 1.60, thanks to
+                // rust-lang/compiler-builtins#452, each compiler routine in `compiler_builtins` is
+                // stored in its own object file. However in `libgcc`, multiple routines are often
+                // grouped into fewer object files. Because the linker is invoked with the following
+                // argument order:
+                //
+                // ```
+                // <Kotlin object file>.o <linkerKonanFlags> <Rust static library> -ldl -lgcc ...
+                // ```
+                //
+                // some compiler routines required by Kotlin are resolved by `compiler_builtins`
+                // before the linker processes `-lgcc`. When the linker tries to resolve other
+                // routines in `libgcc.a`, since the object file containing them also has symbols
+                // already resolved using `compiler_builtins`, the linker fails with
+                // "multiple definition of symbols" errors.
+                //
+                // Therefore, we include `-lgcc` to `linkerKonanFlags` so the linker use `libgcc`
+                // before it encounters object files from `compiler_builtins`, resolving the linker
+                // issue. The symbols will be resolved using `libgcc.a`. Even if the linker
+                // encounters object files in `compiler_builtins`, since the symbols of the same
+                // name are already resolved, the linker will just ignore them, which is the exact
+                // purpose of rust-lang/compiler-builtins#452.
                 compilerOptions.freeCompilerArgs.add(
                     "-Xoverride-konan-properties=linkerKonanFlags.android_arm32=-lgcc -lm -lc++_static -lc++abi -landroid -llog -latomic"
                 )

--- a/examples/app/build.gradle.kts
+++ b/examples/app/build.gradle.kts
@@ -48,13 +48,15 @@ kotlin {
     arrayOf(
         androidNativeArm32()
     ).forEach {
-        it.binaries.configureEach {
-             linkerOpts("-Wl,--allow-multiple-definition")
-//            linkerOpts(
-//                "-Wl,--exclude-libs,libunwind.a",
-//                "-Wl,--exclude-libs,libgcc.a",
-//                "-Wl,--exclude-libs,libgcc_real.a",
-//            )
+        it.compilations.configureEach {
+            compileTaskProvider.configure {
+                // Override Konan properties to make sure libgcc.a is mentioned before any other Rust static libraries
+                // The original linkerKonanFlags.android_arm32 is copied from:
+                // https://github.com/JetBrains/kotlin/blob/6dff5659f42b0b90863d10ee503efd5a8ebb1034/kotlin-native/konan/konan.properties#L839
+                compilerOptions.freeCompilerArgs.add(
+                    "-Xoverride-konan-properties=linkerKonanFlags.android_arm32=-lgcc -lm -lc++_static -lc++abi -landroid -llog -latomic"
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

A follow-up PR for #177.

- Made the bindgen use `kotlinx.cinterop.convert` to cast `Int` to `size_t`.
- Adjusted the linker options of `:examples:app` for Android Native targets to resolve linker errors.

## Testing

- Replaced `./gradlew check` with `./gradlew build` in the CI scripts, making it build for Android NDK targets as well.
- The linked executable is tested manually on a physical device that supports `armeabi-v7a`.

<img width="1659" height="1161" alt="image" src="https://github.com/user-attachments/assets/eaec314a-ec39-4159-8812-138b9e258345" />

## Issues Fixed

Fixes: #186
