### PR TITLE
Fix empty field names being used in `equals()` of tuple variants of enums

### DIFF
--- a/crates/gobley-uniffi-bindgen/src/templates/macros.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/macros.kt
@@ -240,30 +240,30 @@ v{{- field_num -}}
                             {%-     for field in data_class.fields() %}
                             {%-         match field|as_data_class_field_type -%}
                             {%-             when DataClassFieldType::Bytes %}
-{{ " "|repeat(indent) }}    return {{ field.name()|var_name }}.contentEquals(other.{{ field.name()|var_name }})
+{{ " "|repeat(indent) }}    return {% call field_name(field, loop.index) %}.contentEquals(other.{% call field_name(field, loop.index) %})
                             {%-             when DataClassFieldType::NullableBytes %}
-{{ " "|repeat(indent) }}    if ({{ field.name()|var_name }} != null) {
-{{ " "|repeat(indent) }}        if (other.{{ field.name()|var_name }} == null) return false
-{{ " "|repeat(indent) }}        if (!{{ field.name()|var_name }}.contentEquals(other.{{ field.name()|var_name }})) return false
+{{ " "|repeat(indent) }}    if ({% call field_name(field, loop.index) %} != null) {
+{{ " "|repeat(indent) }}        if (other.{% call field_name(field, loop.index) %} == null) return false
+{{ " "|repeat(indent) }}        if (!{% call field_name(field, loop.index) %}.contentEquals(other.{% call field_name(field, loop.index) %})) return false
 {{ " "|repeat(indent) }}    }
 
 {{ " "|repeat(indent) }}    return true
                             {%-             else %}
-{{ " "|repeat(indent) }}    return {{ field.name()|var_name }} == other.{{ field.name()|var_name }}
+{{ " "|repeat(indent) }}    return {% call field_name(field, loop.index) %} == other.{% call field_name(field, loop.index) %}
                             {%-         endmatch -%}
                             {%-     endfor -%}
                             {%- else -%}
                             {%-     for field in data_class.fields() -%}
                             {%-         match field|as_data_class_field_type -%}
                             {%-             when DataClassFieldType::Bytes %}
-{{ " "|repeat(indent) }}    if (!{{ field.name()|var_name }}.contentEquals(other.{{ field.name()|var_name }})) return false
+{{ " "|repeat(indent) }}    if (!{% call field_name(field, loop.index) %}.contentEquals(other.{% call field_name(field, loop.index) %})) return false
                             {%-             when DataClassFieldType::NullableBytes %}
-{{ " "|repeat(indent) }}    if ({{ field.name()|var_name }} != null) {
-{{ " "|repeat(indent) }}        if (other.{{ field.name()|var_name }} == null) return false
-{{ " "|repeat(indent) }}        if (!{{ field.name()|var_name }}.contentEquals(other.{{ field.name()|var_name }})) return false
+{{ " "|repeat(indent) }}    if ({% call field_name(field, loop.index) %} != null) {
+{{ " "|repeat(indent) }}        if (other.{% call field_name(field, loop.index) %} == null) return false
+{{ " "|repeat(indent) }}        if (!{% call field_name(field, loop.index) %}.contentEquals(other.{% call field_name(field, loop.index) %})) return false
 {{ " "|repeat(indent) }}    }
                             {%-             else %}
-{{ " "|repeat(indent) }}    if ({{ field.name()|var_name }} != other.{{ field.name()|var_name }}) return false
+{{ " "|repeat(indent) }}    if ({% call field_name(field, loop.index) %} != other.{% call field_name(field, loop.index) %}) return false
                             {%-         endmatch -%}
                             {%-     endfor %}
 
@@ -283,13 +283,13 @@ v{{- field_num -}}
                             {%-     endif -%}
                             {%-     match field|as_data_class_field_type -%}
                             {%-         when DataClassFieldType::Bytes -%}
-                            {{ field.name()|var_name }}.contentHashCode()
+                            {% call field_name(field, loop.index) %}.contentHashCode()
                             {%-         when DataClassFieldType::NullableBytes -%}
-                            ({{ field.name()|var_name }}?.contentHashCode() ?: 0)
+                            ({% call field_name(field, loop.index) %}?.contentHashCode() ?: 0)
                             {%-         when DataClassFieldType::NonNullableNonBytes -%}
-                            {{ field.name()|var_name }}.hashCode()
+                            {% call field_name(field, loop.index) %}.hashCode()
                             {%-         when DataClassFieldType::NullableNonBytes -%}
-                            ({{ field.name()|var_name }}?.hashCode() ?: 0)
+                            ({% call field_name(field, loop.index) %}?.hashCode() ?: 0)
                             {%-     endmatch -%}
                             {%- endfor -%}
                             {%- if data_class.fields().len() > 1 %}

--- a/tests/uniffi/coverall/src/commonMain/rust/additional.rs
+++ b/tests/uniffi/coverall/src/commonMain/rust/additional.rs
@@ -4,9 +4,11 @@
 
 use std::sync::Arc;
 
+// #74
 #[derive(uniffi::Object)]
 struct NotConstructible {}
 
+// #74
 #[uniffi::export]
 impl NotConstructible {
     #[uniffi::constructor]
@@ -15,20 +17,24 @@ impl NotConstructible {
     }
 }
 
+// #74
 #[uniffi::export]
 fn new_not_constructible() -> Arc<NotConstructible> {
     panic!("function panic")
 }
 
+// #74
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 enum NotConstructibleError {
     #[error("not constructible")]
     NotConstructible,
 }
 
+// #74
 #[derive(uniffi::Object)]
 struct NotConstructible2 {}
 
+// #74
 #[uniffi::export]
 impl NotConstructible2 {
     #[uniffi::constructor]
@@ -37,7 +43,22 @@ impl NotConstructible2 {
     }
 }
 
+// #74
 #[uniffi::export]
 fn new_not_constructible2() -> Result<Arc<NotConstructible2>, NotConstructibleError> {
     Err(NotConstructibleError::NotConstructible)
+}
+
+// #193
+#[derive(uniffi::Enum)]
+enum EnumWithVariousVariants {
+    First,
+    Second(i32, f32),
+    Third(i32, Vec<u8>, String),
+    Fourth { val: i32 },
+    Fifth {
+        val1: i32,
+        val2: Vec<u8>,
+        val3: String,
+    },
 }


### PR DESCRIPTION
## Changes

Replaced occurrences of `{{ field.name()|var_name }}` in macro `generate_equals_hash_code` with `{% call field_name(field, loop.index) %}` as other templates do.

## Testing

Added a new enum, `EnumWithVariousVariants`, to `coverall::additional`.

## Issues Fixed

Fixes: #193
