### PR TITLE
Make the PR test CI workflow run on Windows, macOS, and Linux using GitHub Actions

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -23,21 +23,23 @@ on:
 
 jobs:
   prepare-matrix:
+    name: Prepare matrix
     runs-on: ubuntu-latest
     outputs:
       platforms: ${{ steps.prepare-matrix.outputs.platforms }}
     steps:
-      - id: prepare-matrix
+      - name: Prepare matrix
+        id: prepare-matrix
         shell: pwsh
         run: |
           $eventName = "${{ github.event_name }}"
           if ($eventName -eq "schedule") {
             $platforms = @("windows", "macos", "linux");
           } else {
-            $os = @();
-            if ("${{ github.event.inputs['run-windows-tests'] || 'false' }}" -eq "true") { $os += "windows"; }
-            if ("${{ github.event.inputs['run-macos-tests'] || 'false' }}" -eq "true") { $os += "macos"; }
-            if ("${{ github.event.inputs['run-linux-tests'] || 'false' }}" -eq "true") { $os += "linux"; }
+            $platforms = @();
+            if ("${{ github.event.inputs['run-windows-tests'] || 'false' }}" -eq "true") { $platforms += "windows"; }
+            if ("${{ github.event.inputs['run-macos-tests'] || 'false' }}" -eq "true") { $platforms += "macos"; }
+            if ("${{ github.event.inputs['run-linux-tests'] || 'false' }}" -eq "true") { $platforms += "linux"; }
           }
           $platformsJson = $platforms | ConvertTo-Json -Compress;
           "platforms=$platformsJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append;
@@ -45,7 +47,7 @@ jobs:
     name: Build and run unit tests
     timeout-minutes: 240
     needs: prepare-matrix
-    if: ${{ needs.prepare-matrix.outputs.platforms != '[]' }}
+    if: ${{ (needs.prepare-matrix.outputs.platforms || '[]') != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![License](https://img.shields.io/github/license/gobley/gobley)](https://github.com/gobley/gobley/blob/main/LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/gobley-uniffi-bindgen)](https://crates.io/crates/gobley-uniffi-bindgen)
 [![Gradle Plugin Portal](https://img.shields.io/maven-central/v/dev.gobley.gradle/gobley-gradle)](https://central.sonatype.com/artifact/dev.gobley.gradle/gobley-gradle)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/gobley/gobley/pr-build-test.yml?branch=main&label=tests)](https://github.com/gobley/gobley/actions/workflows/pr-build-test.yml?query=branch%3Amain)
+[![GitHub Actions Workflow Status (All Platforms)](https://img.shields.io/github/actions/workflow/status/gobley/gobley/pr-build-test.yml?branch=main&label=tests:%20Windows%20•%20macOS%20•%20Linux)](https://github.com/gobley/gobley/actions/workflows/pr-build-test.yml?query=branch%3Amain)
+[![GitHub Actions Workflow Status (Docker)](https://img.shields.io/github/actions/workflow/status/gobley/gobley/pr-build-test-docker.yml?branch=main&label=tests:%20Docker)](https://github.com/gobley/gobley/actions/workflows/pr-build-test-docker.yml?query=branch%3Amain)
 
 <img align="right" src=".idea/icon.svg" width="20%">
 


### PR DESCRIPTION
A follow-up PR for #200.

## Changes

- Add test status shields for Windows/macOS tests in README.
- Fixed typos in the PowerShell script of the `prepare-matrix` job in `pr-build-tests.yml`.