### PR TITLE
Run `:tests:uniffi:test:ext-types` separately in CI

### DIFF
--- a/.github/workflows/pr-build-test/copy-test-result.ps1
+++ b/.github/workflows/pr-build-test/copy-test-result.ps1
@@ -1,3 +1,5 @@
+param ([switch]$Force);
+
 $ErrorActionPreference = "Stop";
 $PSNativeCommandUseErrorActionPreference = $true;
 
@@ -16,5 +18,5 @@ foreach ($testResultDirectory in $testResultDirectories) {
         New-Item -Type Directory $destination | Out-Null;
     }
     Write-Host "$testResultDirectory -> $destination"
-    Move-Item $testResultDirectory $destination;
+    Move-Item $testResultDirectory $destination -Force:$Force;
 }

--- a/.github/workflows/pr-build-test/examples.ps1
+++ b/.github/workflows/pr-build-test/examples.ps1
@@ -13,6 +13,7 @@ try {
             ./gradlew ":examples:${project}:build" `
                 "-Pgobley.projects.gradleTests=false" `
                 "-Pgobley.projects.uniffiTests=false" `
+                "-Pgobley.projects.uniffiTests.extTypes=false" `
                 "-Pgobley.projects.uniffiTests.futures=false";
         } finally {
             ./.github/workflows/pr-build-test/copy-test-result.ps1;
@@ -20,6 +21,7 @@ try {
             ./gradlew ":examples:${project}:clean" `
                 "-Pgobley.projects.gradleTests=false" `
                 "-Pgobley.projects.uniffiTests=false" `
+                "-Pgobley.projects.uniffiTests.extTypes=false" `
                 "-Pgobley.projects.uniffiTests.futures=false";
         }
     }
@@ -29,6 +31,7 @@ try {
     ./gradlew clean `
         "-Pgobley.projects.gradleTests=false" `
         "-Pgobley.projects.uniffiTests=false" `
+        "-Pgobley.projects.uniffiTests.extTypes=false" `
         "-Pgobley.projects.uniffiTests.futures=false";
     ./.github/workflows/pr-build-test/change-file-owner.ps1;
 }

--- a/.github/workflows/pr-build-test/gradle-tests.ps1
+++ b/.github/workflows/pr-build-test/gradle-tests.ps1
@@ -6,6 +6,7 @@ $PSNativeCommandUseErrorActionPreference = $true;
 try {
     ./gradlew build `
         "-Pgobley.projects.uniffiTests=false" `
+        "-Pgobley.projects.uniffiTests.extTypes=false" `
         "-Pgobley.projects.uniffiTests.futures=false" `
         "-Pgobley.projects.examples=false";
 } finally {
@@ -13,6 +14,7 @@ try {
     ./gradlew --stop;
     ./gradlew clean `
         "-Pgobley.projects.uniffiTests=false" `
+        "-Pgobley.projects.uniffiTests.extTypes=false" `
         "-Pgobley.projects.uniffiTests.futures=false" `
         "-Pgobley.projects.examples=false";
     ./.github/workflows/pr-build-test/change-file-owner.ps1;

--- a/.github/workflows/pr-build-test/uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test/uniffi-tests.ps1
@@ -4,31 +4,37 @@ $PSNativeCommandUseErrorActionPreference = $true;
 ./.github/workflows/pr-build-test/environment.ps1;
 
 $configurations = @(
-    @{ GenerateImmutableRecords = $false; OmitChecksums = $false; Futures = $false },
-    @{ GenerateImmutableRecords = $true; OmitChecksums = $false; Futures = $false },
-    @{ GenerateImmutableRecords = $false; OmitChecksums = $true; Futures = $false },
-    @{ GenerateImmutableRecords = $true; OmitChecksums = $true; Futures = $false },
-    @{ GenerateImmutableRecords = $false; OmitChecksums = $false; Futures = $true },
-    @{ GenerateImmutableRecords = $true; OmitChecksums = $false; Futures = $true },
-    @{ GenerateImmutableRecords = $false; OmitChecksums = $true; Futures = $true },
-    @{ GenerateImmutableRecords = $true; OmitChecksums = $true; Futures = $true }
+    @{ GenerateImmutableRecords = $false; OmitChecksums = $false; },
+    @{ GenerateImmutableRecords = $true; OmitChecksums = $false; },
+    @{ GenerateImmutableRecords = $false; OmitChecksums = $true; },
+    @{ GenerateImmutableRecords = $true; OmitChecksums = $true; }
+);
+$testGroups = @(
+    $null,
+    "extTypes",
+    "futures"
 );
 
 try {
     foreach ($configuration in $configurations) {
         $generateImmutableRecords = $configuration.GenerateImmutableRecords;
         $omitChecksums = $configuration.OmitChecksums;
-        $futures = $configuration.Futures;
         $additionalArguments = @();
-        if ($futures) { $additionalArguments += "--max-workers=1"; }
-        ./gradlew build `
-            $additionalArguments `
-            "-Pgobley.projects.gradleTests=false" `
-            "-Pgobley.projects.examples=false" `
-            "-Pgobley.projects.uniffiTests=$(-not $futures)" `
-            "-Pgobley.projects.uniffiTests.futures=$futures" `
-            "-Pgobley.projects.uniffiTests.generateImmutableRecords=$generateImmutableRecords" `
-            "-Pgobley.projects.uniffiTests.omitChecksums=$omitChecksums";
+        foreach ($testGroup in $testGroups) {
+            $basicTests = $null -eq $testGroup;
+            $extTypes = "extTypes" -eq $testGroup;
+            $futures = "futures" -eq $testGroup;
+            if ($futures) { $additionalArguments += "--max-workers=1"; }
+            ./gradlew build `
+                $additionalArguments `
+                "-Pgobley.projects.gradleTests=false" `
+                "-Pgobley.projects.examples=false" `
+                "-Pgobley.projects.uniffiTests=$basicTests" `
+                "-Pgobley.projects.uniffiTests.extTypes=$extTypes" `
+                "-Pgobley.projects.uniffiTests.futures=$futures" `
+                "-Pgobley.projects.uniffiTests.generateImmutableRecords=$generateImmutableRecords" `
+                "-Pgobley.projects.uniffiTests.omitChecksums=$omitChecksums";
+        }
     }
 } finally {
     ./.github/workflows/pr-build-test/copy-test-result.ps1;

--- a/.github/workflows/pr-build-test/uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test/uniffi-tests.ps1
@@ -36,7 +36,9 @@ try {
                     "-Pgobley.projects.uniffiTests.generateImmutableRecords=$generateImmutableRecords" `
                     "-Pgobley.projects.uniffiTests.omitChecksums=$omitChecksums";
             } finally {
-                ./.github/workflows/pr-build-test/copy-test-result.ps1;
+                # Allow overwriting the test result to use the last one.
+                # If the test fails, this will copy the result of the failing tests.
+                ./.github/workflows/pr-build-test/copy-test-result.ps1 -Force;
                 ./gradlew --stop;
                 ./gradlew clean `
                     "-Pgobley.projects.gradleTests=false" `

--- a/.github/workflows/pr-build-test/uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test/uniffi-tests.ps1
@@ -25,19 +25,29 @@ try {
             $extTypes = "extTypes" -eq $testGroup;
             $futures = "futures" -eq $testGroup;
             if ($futures) { $additionalArguments += "--max-workers=1"; }
-            ./gradlew build `
-                $additionalArguments `
-                "-Pgobley.projects.gradleTests=false" `
-                "-Pgobley.projects.examples=false" `
-                "-Pgobley.projects.uniffiTests=$basicTests" `
-                "-Pgobley.projects.uniffiTests.extTypes=$extTypes" `
-                "-Pgobley.projects.uniffiTests.futures=$futures" `
-                "-Pgobley.projects.uniffiTests.generateImmutableRecords=$generateImmutableRecords" `
-                "-Pgobley.projects.uniffiTests.omitChecksums=$omitChecksums";
+            try {
+                ./gradlew build `
+                    $additionalArguments `
+                    "-Pgobley.projects.gradleTests=false" `
+                    "-Pgobley.projects.examples=false" `
+                    "-Pgobley.projects.uniffiTests=$basicTests" `
+                    "-Pgobley.projects.uniffiTests.extTypes=$extTypes" `
+                    "-Pgobley.projects.uniffiTests.futures=$futures" `
+                    "-Pgobley.projects.uniffiTests.generateImmutableRecords=$generateImmutableRecords" `
+                    "-Pgobley.projects.uniffiTests.omitChecksums=$omitChecksums";
+            } finally {
+                ./.github/workflows/pr-build-test/copy-test-result.ps1;
+                ./gradlew --stop;
+                ./gradlew clean `
+                    "-Pgobley.projects.gradleTests=false" `
+                    "-Pgobley.projects.examples=false" `
+                    "-Pgobley.projects.uniffiTests=$basicTests" `
+                    "-Pgobley.projects.uniffiTests.extTypes=$extTypes" `
+                    "-Pgobley.projects.uniffiTests.futures=$futures";
+            }
         }
     }
 } finally {
-    ./.github/workflows/pr-build-test/copy-test-result.ps1;
     ./gradlew --stop;
     ./gradlew clean `
         "-Pgobley.projects.gradleTests=false" `

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,6 @@ android.useAndroidX=true
 # Gobley
 gobley.projects.gradleTests=true
 gobley.projects.uniffiTests=true
+gobley.projects.uniffiTests.extTypes=true
 gobley.projects.uniffiTests.futures=true
 gobley.projects.examples=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,14 +48,6 @@ if (ext.propertyIsTrue("gobley.projects.uniffiTests")) {
     include(":tests:uniffi:docstring-proc-macro")
     include(":tests:uniffi:enum-types")
     include(":tests:uniffi:error-types")
-    // Required by ext-types and ext-types-proc-macro
-    include(":examples:custom-types")
-    include(":tests:uniffi:ext-types:custom-types")
-    include(":tests:uniffi:ext-types:ext-types")
-    include(":tests:uniffi:ext-types:ext-types-proc-macro")
-    include(":tests:uniffi:ext-types:http-headermap")
-    include(":tests:uniffi:ext-types:sub-lib")
-    include(":tests:uniffi:ext-types:uniffi-one")
     include(":tests:uniffi:keywords")
     include(":tests:uniffi:large-enum")
     include(":tests:uniffi:large-error")
@@ -65,6 +57,17 @@ if (ext.propertyIsTrue("gobley.projects.uniffiTests")) {
     include(":tests:uniffi:struct-default-values")
     include(":tests:uniffi:trait-methods")
     include(":tests:uniffi:type-limits")
+}
+// Run :tests:uniffi:ext-types separately
+if (ext.propertyIsTrue("gobley.projects.uniffiTests.extTypes")) {
+    // Required by ext-types and ext-types-proc-macro
+    include(":examples:custom-types")
+    include(":tests:uniffi:ext-types:custom-types")
+    include(":tests:uniffi:ext-types:ext-types")
+    include(":tests:uniffi:ext-types:ext-types-proc-macro")
+    include(":tests:uniffi:ext-types:http-headermap")
+    include(":tests:uniffi:ext-types:sub-lib")
+    include(":tests:uniffi:ext-types:uniffi-one")
 }
 // Run :tests:uniffi:futures separately
 if (ext.propertyIsTrue("gobley.projects.uniffiTests.futures")) {


### PR DESCRIPTION
The UniFFI Docker tests are failing due to a no space left error. This PR splits UniFFI tests further to prevent such errors by adding a new Gradle property, `gobley.projects.uniffiTests.extTypes`, which controls the enabling of `:tests:uniffi:ext-types` and `:examples:custom-types`.