### PR TITLE
Replace backslahes in Bindgen extra Clang args with slashes

### DIFF
--- a/build-logic/gobley-gradle/src/main/kotlin/rust/targets/RustAndroidTarget.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/rust/targets/RustAndroidTarget.kt
@@ -102,7 +102,8 @@ enum class RustAndroidTarget(
             "CXX_$rustTriple" to clangCpp,
             "AR_$rustTriple" to ar,
             "RANLIB_$rustTriple" to ranlib,
-            "BINDGEN_EXTRA_CLANG_ARGS_$rustTriple" to "--sysroot=$sysroot -I$sysrootExtraInclude",
+            "BINDGEN_EXTRA_CLANG_ARGS_$rustTriple" to "--sysroot=$sysroot -I$sysrootExtraInclude"
+                .replace('\\', '/'),
         )
     }
 


### PR DESCRIPTION
## Changes

A follow-up PR for #224. Fixes bindgen failing when targeting Android on Windows.

## Testing

https://github.com/paxbun/gobley/actions/runs/18195361025/job/51800098695

Manually tested in a GitHub Actions workflow by disabling projects other than `:examples:tokio-boring-app`.

<img width="767" height="300" alt="image" src="https://github.com/user-attachments/assets/d3d91e22-75a0-4de6-be68-4599c27d2c2b" />

```diff
diff --git a/.github/workflows/pr-build-test.yml b/.github/workflows/pr-build-test.yml
index 77bc482a..5c518af2 100644
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -66,11 +66,11 @@ jobs:
       fail-fast: false
       matrix:
         test-name:
-          # - cargo-tests
+          - cargo-tests
           - examples
-          # - gradle-plugin-tests
-          # - gradle-tests
-          # - uniffi-tests
+          - gradle-plugin-tests
+          - gradle-tests
+          - uniffi-tests
         platform: ${{ fromJSON(needs.prepare-matrix.outputs.platforms) }}
     runs-on: ${{ fromJSON(needs.prepare-matrix.outputs.runners)[matrix.platform] }}
     steps:
@@ -92,15 +92,8 @@ jobs:
       - name: Install additional required Android SDK packages and configure environment variables
         shell: pwsh
         run: |
-          sdkmanager --install "ndk;27.0.12077973";
-          $ndkHost = if ($IsWindows) {
-            "windows-x86_64"
-          } elseif ($IsMacOS) {
-            "darwin-x86_64"
-          } else {
-            "linux-x86_64"
-          };
-          ls "${env:ANDROID_SDK_ROOT}/ndk/27.0.12077973/toolchains/llvm/prebuilt/$ndkHost/sysroot/usr/include/sys";
+          sdkmanager --install "ndk;27.0.12077973"
+          "ANDROID_HOME=${env:ANDROID_SDK_ROOT}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Run tests
         shell: pwsh
         run: ./.github/workflows/pr-build-test/${{ matrix.test-name }}.ps1
diff --git a/.github/workflows/pr-build-test/examples.ps1 b/.github/workflows/pr-build-test/examples.ps1
index 8a587a39..8215c86f 100644
--- a/.github/workflows/pr-build-test/examples.ps1
+++ b/.github/workflows/pr-build-test/examples.ps1
@@ -4,10 +4,9 @@ $PSNativeCommandUseErrorActionPreference = $true;
 ./.github/workflows/pr-build-test/environment.ps1;
 
 # Run build project-wise to prevent no space left errors
-# $projects = Get-ChildItem ./examples |
-#     ? { Test-Path "$_/build.gradle.kts" } |
-#     % { $_.Name };
-$projects = @("tokio-boring-app");
+$projects = Get-ChildItem ./examples |
+    ? { Test-Path "$_/build.gradle.kts" } |
+    % { $_.Name };
 try {
     foreach ($project in $projects) {
         try {
diff --git a/settings.gradle.kts b/settings.gradle.kts
index a53d6287..8dbffa78 100644
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,11 +75,11 @@ if (ext.propertyIsTrue("gobley.projects.uniffiTests.futures")) {
 }
 
 if (ext.propertyIsTrue("gobley.projects.examples")) {
-//    include(":examples:app")
-//    include(":examples:arithmetic-procmacro")
-//    include(":examples:audio-cpp-app")
-//    include(":examples:custom-types")
-//    include(":examples:todolist")
-//    include(":examples:tokio-blake3-app")
+    include(":examples:app")
+    include(":examples:arithmetic-procmacro")
+    include(":examples:audio-cpp-app")
+    include(":examples:custom-types")
+    include(":examples:todolist")
+    include(":examples:tokio-blake3-app")
     include(":examples:tokio-boring-app")
 }
```