### PR TITLE
Remove RustBufferByReference

### DIFF
--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/RustBufferTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/RustBufferTemplate.kt
@@ -46,23 +46,6 @@ internal fun RustBufferByValue.asByteBuffer(): ByteBuffer? {
     return ByteBuffer(data?.getByteBuffer(0L, this.len) ?: return null)
 }
 
-internal class RustBufferByReference : com.sun.jna.ptr.ByReference(16)
-internal fun RustBufferByReference.setValue(value: RustBufferByValue) {
-    // NOTE: The offsets are as they are in the C-like struct.
-    val pointer = getPointer()
-    pointer.setLong(0, value.capacity)
-    pointer.setLong(8, value.len)
-    pointer.setPointer(16, value.data)
-}
-internal fun RustBufferByReference.getValue(): RustBufferByValue {
-    val pointer = getPointer()
-    val value = RustBufferByValue()
-    value.writeField("capacity", pointer.getLong(0))
-    value.writeField("len", pointer.getLong(8))
-    value.writeField("data", pointer.getLong(16))
-    return value
-}
-
 // This is a helper for safely passing byte references into the rust code.
 // It's not actually used at the moment, because there aren't many things that you
 // can take a direct pointer to in the JVM, and if we're going to copy something

--- a/crates/gobley-uniffi-bindgen/src/templates/headers/RustBufferTemplate.h
+++ b/crates/gobley-uniffi-bindgen/src/templates/headers/RustBufferTemplate.h
@@ -6,13 +6,6 @@ typedef struct RustBuffer
     uint8_t *_Nullable data;
 } RustBuffer;
 
-typedef struct RustBufferByReference
-{
-    int64_t capacity;
-    int64_t len;
-    uint8_t *_Nullable data;
-} RustBufferByReference;
-
 typedef struct ForeignBytes
 {
     int32_t len;

--- a/crates/gobley-uniffi-bindgen/src/templates/native/RustBufferTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/native/RustBufferTemplate.kt
@@ -45,23 +45,6 @@
     )
 }
 
-/**
- * The equivalent of the `*mut RustBuffer` type.
- * Required for callbacks taking in an out pointer.
- *
- * Size is the sum of all values in the struct.
- */
-internal typealias RustBufferByReference = CPointer<{{ ci.namespace() }}.cinterop.RustBufferByReference>
-
-internal fun RustBufferByReference.setValue(value: RustBufferByValue) {
-    pointed.capacity = value.capacity
-    pointed.len = value.len
-    pointed.data = value.data?.reinterpret()
-}
-internal fun RustBufferByReference.getValue(): RustBufferByValue
-    = pointed.reinterpret<{{ ci.namespace() }}.cinterop.RustBuffer>().readValue()
-
-
 internal typealias ForeignBytes = CPointer<{{ ci.namespace() }}.cinterop.ForeignBytes>
 internal var ForeignBytes.len: Int
     get() = pointed.len


### PR DESCRIPTION
RustBufferByReference is not currently being used. See https://github.com/mozilla/uniffi-rs/pull/2683 for details.