### PR TITLE
Make `pr-build-test-report-docker.yml` continue running even when artifacts don't exist

### DIFF
--- a/.github/workflows/pr-build-test-report-docker.yml
+++ b/.github/workflows/pr-build-test-report-docker.yml
@@ -31,12 +31,15 @@ jobs:
     steps:
       - name: Download test results
         uses: actions/download-artifact@v4
+        id: download
+        continue-on-error: true
         with:
           name: junit-test-results-${{ matrix.test-name }}-docker
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Report test results
         uses: mikepenz/action-junit-report@v5
+        if: ${{ steps.download.outcome == 'success' }}
         with:
           check_name: 'JUnit Docker test report (${{ matrix.test-name }})'
           commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
A follow-up PR for #234. Some tests like `examples-audio-cpp-app` don't have unit tests, so they don't upload any artifacts. To ensure PR test workflows share the same `test-name` list, this PR makes `pr-build-test-report-docker.yml` continue running even when artifacts don't exist.