### PR TITLE
Render the missing dynamic library dependency loading logic

### DIFF
--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
@@ -125,6 +125,9 @@ internal object IntegrityCheckingUniffiLib : Library {
 internal object UniffiLib : Library {
     init {
         IntegrityCheckingUniffiLib
+        {%- for dynamic_library in config.dynamic_library_dependencies(module_name) %}
+        Native.register(object : Library {}::class.java, "{{ dynamic_library }}")
+        {%- endfor %}
         Native.register(UniffiLib::class.java, findLibraryName("{{ ci.namespace() }}"))
         // No need to check the contract version and checksums, since 
         // we already did that with `IntegrityCheckingUniffiLib` above.


### PR DESCRIPTION
A follow-up PR for #227. Fixed the regression where the dynamic library dependency loading logic is not being rendered.