### PR TITLE
Fix the nightly toolchain used in the CI to a specific version

### DIFF
--- a/.github/workflows/pr-build-test/dependencies.ps1
+++ b/.github/workflows/pr-build-test/dependencies.ps1
@@ -14,9 +14,24 @@ if ($IsWindows) {
 } elseif ($IsMacOS) {
     brew update;
     brew install mingw-w64;
-    # Workaround for #205
-    rustup install nightly;
-    rustup component add rust-src --toolchain nightly;
+
+    # Workaround for #205 and #206.
+    # Manually install nightly Rust for watchOS and tvOS.
+    # To fix the nightly toolchain to a specific version, remove the pre-installed one.
+    rustup uninstall nightly;
+    # Install 1.84.0-nightly (798fb83f7 2024-10-16).
+    $version = "nightly-2024-10-17";
+    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture;
+    $rustTriplet = switch ($osArch) {
+        "X64" { "x86_64-apple-darwin" }
+        "Arm64" { "aarch64-apple-darwin" }
+        default { $null }
+    };
+    rustup install $version;
+    rustup component add rust-src --toolchain $version;
+    # Use the version-fixed nightly as the default nightly toolchain.
+    ln -s "$HOME/.rustup/toolchains/$version-$rustTriplet" "$HOME/.rustup/toolchains/nightly-$rustTriplet";
+    Remove-Variable version;
 } elseif ($IsLinux) {
     sudo apt-get update;
     sudo apt-get install -y mingw-w64;


### PR DESCRIPTION
## Changes

The standard library of Rust `nightly-2025-10-15` has compilation errors (See rust-lang/rust#147776). This PR fixes the nightly version used in the CI to `nightly-2024-10-17`, the one released with stable 1.82.0, which is used in `rust-toolchain.toml`.

## Testing

macOS: https://github.com/paxbun/gobley/actions/runs/18769702258

<img width="1476" height="892" alt="image" src="https://github.com/user-attachments/assets/09ada412-1bcd-4b34-adb9-b748d72234e5" />
