### PR TITLE
Fix `import org.khronos.webgl.ArrayBuffer` present only when `package_name` is also present

### DIFF
--- a/crates/gobley-wasm-transformer/src/templates/js.kt
+++ b/crates/gobley-wasm-transformer/src/templates/js.kt
@@ -1,9 +1,8 @@
 {%- if let Some(package_name) = package_name -%}
 package {{ package_name }}
 
-import org.khronos.webgl.ArrayBuffer
-
 {% endif -%}
+
 private const val BASE64 = "{{ base64 }}"
 
 private external interface Buffer {
@@ -26,7 +25,7 @@ internal external class WebAssembly {
     }
 
     class Memory(descriptor: Any) {
-        val buffer: ArrayBuffer
+        val buffer: org.khronos.webgl.ArrayBuffer
         fun grow(delta: Int)
     }
 


### PR DESCRIPTION
## Changes

`gobley-wasm-transformer` is emitting `import org.khronos.webgl.ArrayBuffer` only when it is given a `package_name`. Replaced the ocurrences of `ArrayBuffer` with `org.khronos.webgl.ArrayBuffer` so import issue won't happen even when `package_name` is not present.