### PR TITLE
Add a temporary bindgen config option to enable interface mapping

### DIFF
--- a/.github/workflows/pr-build-test-docker.yml
+++ b/.github/workflows/pr-build-test-docker.yml
@@ -33,6 +33,7 @@ jobs:
           - uniffi-tests-gir
           - uniffi-tests-oc
           - uniffi-tests-gir-oc
+          - uniffi-tests-im
     steps:
       - uses: actions/checkout@v4
       - name: Docker login to GitHub Container Registry

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -88,6 +88,7 @@ jobs:
           - uniffi-tests-gir
           - uniffi-tests-oc
           - uniffi-tests-gir-oc
+          - uniffi-tests-im
         platform: ${{ fromJSON(needs.prepare-matrix.outputs.platforms) }}
     runs-on: ${{ fromJSON(needs.prepare-matrix.outputs.runners)[matrix.platform] }}
     steps:

--- a/.github/workflows/pr-build-test/uniffi-tests-im.ps1
+++ b/.github/workflows/pr-build-test/uniffi-tests-im.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = "Stop";
+$PSNativeCommandUseErrorActionPreference = $true;
+
+./.github/workflows/pr-build-test/uniffi-tests.ps1 -EnableJnaInterfaceMapping;

--- a/.github/workflows/pr-build-test/uniffi-tests.ps1
+++ b/.github/workflows/pr-build-test/uniffi-tests.ps1
@@ -1,6 +1,7 @@
 param (
     [switch]$GenerateImmutableRecords,
-    [switch]$OmitChecksums
+    [switch]$OmitChecksums,
+    [switch]$EnableJnaInterfaceMapping
 );
 
 $ErrorActionPreference = "Stop";
@@ -30,7 +31,8 @@ try {
                 "-Pgobley.projects.uniffiTests.extTypes=$extTypes" `
                 "-Pgobley.projects.uniffiTests.futures=$futures" `
                 "-Pgobley.projects.uniffiTests.generateImmutableRecords=$GenerateImmutableRecords" `
-                "-Pgobley.projects.uniffiTests.omitChecksums=$OmitChecksums";
+                "-Pgobley.projects.uniffiTests.omitChecksums=$OmitChecksums" `
+                "-Pgobley.projects.uniffiTests.enableJnaInterfaceMapping=$EnableJnaInterfaceMapping";
         } finally {
             # Allow overwriting the test result to use the last one.
             # If the test fails, this will copy the result of the failing tests.

--- a/build-logic/conventions/src/main/kotlin/uniffi-tests-from-library.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/uniffi-tests-from-library.gradle.kts
@@ -1,3 +1,4 @@
+import gobley.gradle.InternalGobleyGradleApi
 import org.gradle.api.Project
 
 plugins {
@@ -17,5 +18,8 @@ uniffi {
             propertyIsTrue("gobley.projects.uniffiTests.generateImmutableRecords", false)
         omitChecksums =
             propertyIsTrue("gobley.projects.uniffiTests.omitChecksums", false)
+        @OptIn(InternalGobleyGradleApi::class)
+        enableJnaInterfaceMapping =
+            propertyIsTrue("gobley.projects.uniffiTests.enableJnaInterfaceMapping", false)
     }
 }

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/Config.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/Config.kt
@@ -38,6 +38,7 @@ internal data class Config(
     @SerialName("jvm_dynamic_library_dependencies") val jvmDynamicLibraryDependencies: List<String>? = null,
     @SerialName("android_dynamic_library_dependencies") val androidDynamicLibraryDependencies: List<String>? = null,
     @SerialName("dynamic_library_dependencies") val dynamicLibraryDependencies: List<String>? = null,
+    @SerialName("__enable_jna_interface_mapping") val enableJnaInterfaceMapping: Boolean? = null
 ) {
     @Serializable
     internal data class CustomType(

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -244,6 +244,8 @@ class UniFfiPlugin : Plugin<Project> {
             customTypes.set(bindingsGeneration.customTypes)
             disableJavaCleaner.set(bindingsGeneration.disableJavaCleaner)
             usePascalCaseEnumClass.set(bindingsGeneration.usePascalCaseEnumClass)
+            @OptIn(InternalGobleyGradleApi::class)
+            enableJnaInterfaceMapping.set(bindingsGeneration.enableJnaInterfaceMapping)
 
             @OptIn(InternalGobleyGradleApi::class)
             kotlinMultiplatform.set(kotlinExtensionDelegate.pluginId == PluginIds.KOTLIN_MULTIPLATFORM)

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/BindingsGeneration.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/BindingsGeneration.kt
@@ -6,6 +6,7 @@
 
 package gobley.gradle.uniffi.dsl
 
+import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.Variant
 import gobley.gradle.rust.targets.RustTarget
 import org.gradle.api.Action
@@ -90,6 +91,14 @@ sealed class BindingsGeneration(internal val project: Project) {
      * When `true`, enum classes will use PascalCase instead of UPPER_SNAKE_CASE.
      */
     abstract val usePascalCaseEnumClass: Property<Boolean>
+
+    /**
+     * When `true`, the generated bindings will use JNA interface mapping instead of
+     * [direct mapping](https://github.com/java-native-access/jna/blob/master/www/DirectMapping.md).
+     */
+    // TODO: Remove InternalGobleyGradleApi in 0.4.0
+    @InternalGobleyGradleApi
+    abstract val enableJnaInterfaceMapping: Property<Boolean>
 }
 
 abstract class BindingsGenerationFromLibrary @Inject internal constructor(project: Project) :

--- a/crates/gobley-uniffi-bindgen/src/gen_kotlin_multiplatform/mod.rs
+++ b/crates/gobley-uniffi-bindgen/src/gen_kotlin_multiplatform/mod.rs
@@ -126,6 +126,8 @@ pub struct Config {
     android_dynamic_library_dependencies: Vec<String>,
     #[serde(default)]
     dynamic_library_dependencies: Vec<String>,
+    #[serde(default, rename = "__enable_jna_interface_mapping")]
+    enable_jna_interface_mapping: Option<bool>,
 }
 
 // TODO: Make this public in 0.4.0
@@ -259,6 +261,10 @@ impl Config {
             // correct namespace.
             None => format!("uniffi.{}", namespace.unwrap_or(module_path)),
         }
+    }
+
+    pub fn enable_jna_interface_mapping(&self) -> bool {
+        self.enable_jna_interface_mapping.unwrap_or(false)
     }
 }
 
@@ -1347,9 +1353,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_free(ci);
-        Ok(format!(
-            "{{ future -> UniffiLib.{ffi_func}(future) }}"
-        ))
+        Ok(format!("{{ future -> UniffiLib.{ffi_func}(future) }}"))
     }
 
     pub fn async_cancel(
@@ -1357,9 +1361,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_cancel(ci);
-        Ok(format!(
-            "{{ future -> UniffiLib.{ffi_func}(future) }}"
-        ))
+        Ok(format!("{{ future -> UniffiLib.{ffi_func}(future) }}"))
     }
 
     /// Remove the "`" chars we put around function/variable names

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
@@ -1,6 +1,12 @@
 
 // Define FFI callback types
-
+{%- let lib_private_fun_indent %}
+{%- if config.enable_jna_interface_mapping() %}
+    {%- let lib_private_fun_indent = 8 %}
+{%- else %}
+    {%- let lib_private_fun_indent = 4 %}
+{%- endif %}
+{%- let dynamic_library_dependencies = config.dynamic_library_dependencies(module_name) %}
 {%- for def in ci.ffi_definitions() %}
 {%- match def %}
 {%- when FfiDefinition::CallbackFunction(callback) %}
@@ -66,6 +72,12 @@ private fun findLibraryName(componentName: String): String {
     return "{{ config.cdylib_name() }}"
 }
 
+{%- if config.enable_jna_interface_mapping() %}
+private inline fun <reified Lib : Library> loadIndirect(componentName: String): Lib {
+    return Native.load<Lib>(findLibraryName(componentName), Lib::class.java)
+}
+{%- endif %}
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -79,6 +91,16 @@ private fun findLibraryName(componentName: String): String {
 // The `ffi_uniffi_contract_version` method and all checksum methods are put 
 // into `IntegrityCheckingUniffiLib` and these methods are called only once,
 // when the library is loaded.
+{%- if config.enable_jna_interface_mapping() %}
+internal interface IntegrityCheckingUniffiLib : Library {
+    companion object : IntegrityCheckingUniffiLib by loadIndirect("{{ ci.namespace() }}") {
+        init {
+            uniffiCheckContractApiVersion()
+            {%- if !config.omit_checksums %}
+            uniffiCheckApiChecksums()
+            {%- endif %}
+        }
+{%- else %}
 internal object IntegrityCheckingUniffiLib : Library {
     init {
         Native.register(IntegrityCheckingUniffiLib::class.java, findLibraryName("{{ ci.namespace() }}"))
@@ -87,34 +109,43 @@ internal object IntegrityCheckingUniffiLib : Library {
         uniffiCheckApiChecksums()
         {%- endif %}
     }
+{%- endif %}
 
-    private fun uniffiCheckContractApiVersion() {
-        // Get the bindings contract version from our ComponentInterface
-        val bindingsContractVersion = {{ ci.uniffi_contract_version() }}
-        // Get the scaffolding contract version by calling the into the dylib
-        val scaffoldingContractVersion = {{ ci.ffi_uniffi_contract_version().name() }}()
-        if (bindingsContractVersion != scaffoldingContractVersion) {
-            throw RuntimeException("UniFFI contract version mismatch: try cleaning and rebuilding your project")
-        }
-    }
+{{ " "|repeat(lib_private_fun_indent) }}private fun uniffiCheckContractApiVersion() {
+{{ " "|repeat(lib_private_fun_indent) }}    // Get the bindings contract version from our ComponentInterface
+{{ " "|repeat(lib_private_fun_indent) }}    val bindingsContractVersion = {{ ci.uniffi_contract_version() }}
+{{ " "|repeat(lib_private_fun_indent) }}    // Get the scaffolding contract version by calling the into the dylib
+{{ " "|repeat(lib_private_fun_indent) }}    val scaffoldingContractVersion = {{ ci.ffi_uniffi_contract_version().name() }}()
+{{ " "|repeat(lib_private_fun_indent) }}    if (bindingsContractVersion != scaffoldingContractVersion) {
+{{ " "|repeat(lib_private_fun_indent) }}        throw RuntimeException("UniFFI contract version mismatch: try cleaning and rebuilding your project")
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}}
 
-    {%- if !config.omit_checksums %}
-    {%- if ci.iter_checksums().next().is_none() %}
-    @Suppress("UNUSED_PARAMETER")
-    {%- endif %}
-    private fun uniffiCheckApiChecksums() {
-        {%- for (name, expected_checksum) in ci.iter_checksums() %}
-        if ({{ name }}() != {{ expected_checksum }}.toShort()) {
-            throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-        }
-        {%- endfor %}
+                                        {%- if !config.omit_checksums %}
+                                        {%- if ci.iter_checksums().next().is_none() %}
+
+{{ " "|repeat(lib_private_fun_indent) }}@Suppress("UNUSED_PARAMETER")
+                                        {%- endif %}
+{{ " "|repeat(lib_private_fun_indent) }}private fun uniffiCheckApiChecksums() {
+                                            {%- for (name, expected_checksum) in ci.iter_checksums() %}
+{{ " "|repeat(lib_private_fun_indent) }}    if ({{ name }}() != {{ expected_checksum }}.toShort()) {
+{{ " "|repeat(lib_private_fun_indent) }}        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+{{ " "|repeat(lib_private_fun_indent) }}    }
+                                            {%- endfor %}
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+                                        {%- endif %}
+    {%- if config.enable_jna_interface_mapping() %}
     }
     {%- endif %}
 
     // Integrity check functions only
     {%- for func in ci.iter_ffi_function_integrity_checks() %}
+    {%- if config.enable_jna_interface_mapping() %}
+    fun
+    {%- else %}
     @JvmStatic
-    external fun {{ func.name() }}(
+    external fun
+    {%- endif %} {{ func.name() }}(
         {%- call kt::arg_list_ffi_decl(func, 8) %}
     ): {% match func.return_type() %}{% when Some(return_type) %}{{ return_type.borrow()|ffi_type_name_by_value(ci) }}{% when None %}Unit{% endmatch %}
     {%- endfor %}
@@ -122,120 +153,28 @@ internal object IntegrityCheckingUniffiLib : Library {
 
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
+{%- if config.enable_jna_interface_mapping() %}
+internal interface UniffiLib : Library {
+    companion object : UniffiLib by loadIndirect("{{ ci.namespace() }}") {
+        init {
+            {%- if !dynamic_library_dependencies.is_empty() %}
+            loadDynamicLibraryDependencies(
+                {%- for dynamic_library in config.dynamic_library_dependencies(module_name) %}
+                "{{ dynamic_library }}",
+                {%- endfor %}
+                // Load the main library as well
+                findLibraryName("{{ ci.namespace() }}"),
+            )
+            {%- endif %}
+            IntegrityCheckingUniffiLib
+            // No need to check the contract version and checksums, since 
+            // we already did that with `IntegrityCheckingUniffiLib` above.
+            {%- for init_fn in self.initialization_fns(ci) %}
+            {{ init_fn }}
+            {%- endfor %}
+        }
+{%- else %}
 internal object UniffiLib : Library {
-    {%- let dynamic_library_dependencies = config.dynamic_library_dependencies(module_name) %}
-    {%- if !dynamic_library_dependencies.is_empty() %}
-    {%- if module_name == "jvm" %}
-    // Dynamic library dependency loading code.
-    //
-    // Load dynamic libraries that the main Rust library depends on. They may
-    // reside inside a .jar file, or already be installed in the file system.
-    // The reason for this custom handling is that JNA copies the extracted
-    // library to a temporary file with a random name, resulting in a dynamic
-    // link error on Windows. This logic ensures that the destination temporary
-    // file has the same base name as the original library file in the JAR file.
-    //
-    // First, try loading the library without searching the directories
-    // specified in CLASSPATH.
-    @Suppress("SameParameterValue")
-    private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
-        val nilClasspathClassLoader = java.net.URLClassLoader(emptyArray(), Any::class.java.classLoader)
-        val dependenciesRequiringExtraction = mutableListOf<String>()
-        for (dependency in dependencies) {
-            try {
-                com.sun.jna.NativeLibrary.getInstance(dependency, nilClasspathClassLoader)
-            } catch (_: UnsatisfiedLinkError) {
-                dependenciesRequiringExtraction.add(dependency)
-            }
-        }
-        loadDynamicLibraryDependenciesByExtraction(dependenciesRequiringExtraction, nilClasspathClassLoader)
-    }
-
-    // Second, try extracting the library from a .jar file.
-    private fun loadDynamicLibraryDependenciesByExtraction(
-        dependencies: List<String>,
-        nilClasspathClassLoader: ClassLoader,
-    ) {
-        if (dependencies.isEmpty()) return
-        // The directory where the dynamic library dependencies in zipped JAR files will be extracted
-        val extractionDestination = java.nio.file.Files.createTempDirectory("gobley-jna").toFile()
-        val classLoader = UniffiLib::class.java.classLoader!!
-        val dependenciesRequiringJnaHandling = mutableListOf<String>()
-        for (dependency in dependencies) {
-            val libraryFile = findLibraryInClassPath(dependency, classLoader, extractionDestination)
-            if (libraryFile == null) {
-                dependenciesRequiringJnaHandling.add(dependency)
-                continue
-            }
-            try {
-                com.sun.jna.NativeLibrary.addSearchPath(
-                    dependency,
-                    libraryFile.parentFile.absolutePath,
-                )
-                com.sun.jna.NativeLibrary.getInstance(
-                    dependency,
-                    nilClasspathClassLoader,
-                )
-            } catch (_: UnsatisfiedLinkError) {
-                dependenciesRequiringJnaHandling.add(dependency)
-            }
-        }
-        // Lastly, if all the logic above fails, try loading the library using JNA.
-        for (dependency in dependenciesRequiringJnaHandling) {
-            com.sun.jna.NativeLibrary.getInstance(dependency)
-        }
-    }
-
-    private fun findLibraryInClassPath(
-        library: String,
-        classLoader: ClassLoader,
-        extractionDestination: java.io.File,
-    ): java.io.File? {
-        var libraryName = System.mapLibraryName(library)
-        if (com.sun.jna.Platform.isMac()) {
-            if (libraryName.endsWith(".jnilib")) {
-                libraryName = libraryName.removeSuffix(".jnilib") + ".dylib"
-            }
-        }
-        val resourcePath = "${com.sun.jna.Platform.RESOURCE_PREFIX}/$libraryName"
-        var url = classLoader.getResource(resourcePath)
-        if (com.sun.jna.Platform.isMac() && url == null) {
-            url = classLoader.getResource("darwin/$libraryName")
-        }
-        if (url == null) {
-            url = classLoader.getResource(libraryName)
-        }
-        if (url == null) {
-            return null
-        }
-        if (url.protocol.equals("file", ignoreCase = true)) {
-            val file = try {
-                java.io.File(url.toURI())
-            } catch (_: java.net.URISyntaxException) {
-                java.io.File(url.path)
-            }
-            return file.takeIf { it.exists() }
-        }
-        val destination = extractionDestination.resolve(resourcePath).apply {
-            parentFile?.mkdirs()
-            deleteOnExit()
-        }
-        url.openStream().use { inputStream ->
-            destination.outputStream().use { outputStream ->
-                inputStream.copyTo(outputStream)
-            }
-        }
-        return destination
-    }
-    {%- else %}
-    private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
-        for (dependency in dependencies) {
-            com.sun.jna.NativeLibrary.getInstance(dependency)
-        }
-    }
-    {%- endif %}
-    {%- endif %}
-
     init {
         {%- if !dynamic_library_dependencies.is_empty() %}
         loadDynamicLibraryDependencies(
@@ -254,17 +193,138 @@ internal object UniffiLib : Library {
         {{ init_fn }}
         {%- endfor %}
     }
+{%- endif %}
 
-    {%- if ci.contains_object_types() %}
-    // The Cleaner for the whole library
-    internal val CLEANER: UniffiCleaner by lazy {
-        UniffiCleaner.create()
+                                        {%- if ci.contains_object_types() %}
+{{ " "|repeat(lib_private_fun_indent) }}// The Cleaner for the whole library
+{{ " "|repeat(lib_private_fun_indent) }}internal val CLEANER: UniffiCleaner by lazy {
+{{ " "|repeat(lib_private_fun_indent) }}    UniffiCleaner.create()
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+                                        {%- endif %}
+
+                                        {%- if !dynamic_library_dependencies.is_empty() %}
+                                        {%- if module_name == "jvm" %}
+{{ " "|repeat(lib_private_fun_indent) }}// Dynamic library dependency loading code.
+{{ " "|repeat(lib_private_fun_indent) }}//
+{{ " "|repeat(lib_private_fun_indent) }}// Load dynamic libraries that the main Rust library depends on. They may
+{{ " "|repeat(lib_private_fun_indent) }}// reside inside a .jar file, or already be installed in the file system.
+{{ " "|repeat(lib_private_fun_indent) }}// The reason for this custom handling is that JNA copies the extracted
+{{ " "|repeat(lib_private_fun_indent) }}// library to a temporary file with a random name, resulting in a dynamic
+{{ " "|repeat(lib_private_fun_indent) }}// link error on Windows. This logic ensures that the destination temporary
+{{ " "|repeat(lib_private_fun_indent) }}// file has the same base name as the original library file in the JAR file.
+{{ " "|repeat(lib_private_fun_indent) }}//
+{{ " "|repeat(lib_private_fun_indent) }}// First, try loading the library without searching the directories
+{{ " "|repeat(lib_private_fun_indent) }}// specified in CLASSPATH.
+{{ " "|repeat(lib_private_fun_indent) }}@Suppress("SameParameterValue")
+{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
+{{ " "|repeat(lib_private_fun_indent) }}    val nilClasspathClassLoader = java.net.URLClassLoader(emptyArray(), Any::class.java.classLoader)
+{{ " "|repeat(lib_private_fun_indent) }}    val dependenciesRequiringExtraction = mutableListOf<String>()
+{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
+{{ " "|repeat(lib_private_fun_indent) }}        try {
+{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.getInstance(dependency, nilClasspathClassLoader)
+{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: UnsatisfiedLinkError) {
+{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringExtraction.add(dependency)
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    loadDynamicLibraryDependenciesByExtraction(dependenciesRequiringExtraction, nilClasspathClassLoader)
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+
+{{ " "|repeat(lib_private_fun_indent) }}// Second, try extracting the library from a .jar file.
+{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependenciesByExtraction(
+{{ " "|repeat(lib_private_fun_indent) }}    dependencies: List<String>,
+{{ " "|repeat(lib_private_fun_indent) }}    nilClasspathClassLoader: ClassLoader,
+{{ " "|repeat(lib_private_fun_indent) }}) {
+{{ " "|repeat(lib_private_fun_indent) }}    if (dependencies.isEmpty()) return
+{{ " "|repeat(lib_private_fun_indent) }}    // The directory where the dynamic library dependencies in zipped JAR files will be extracted
+{{ " "|repeat(lib_private_fun_indent) }}    val extractionDestination = java.nio.file.Files.createTempDirectory("gobley-jna").toFile()
+{{ " "|repeat(lib_private_fun_indent) }}    val classLoader = UniffiLib::class.java.classLoader!!
+{{ " "|repeat(lib_private_fun_indent) }}    val dependenciesRequiringJnaHandling = mutableListOf<String>()
+{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
+{{ " "|repeat(lib_private_fun_indent) }}        val libraryFile = findLibraryInClassPath(dependency, classLoader, extractionDestination)
+{{ " "|repeat(lib_private_fun_indent) }}        if (libraryFile == null) {
+{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringJnaHandling.add(dependency)
+{{ " "|repeat(lib_private_fun_indent) }}            continue
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}        try {
+{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.addSearchPath(
+{{ " "|repeat(lib_private_fun_indent) }}                dependency,
+{{ " "|repeat(lib_private_fun_indent) }}                libraryFile.parentFile.absolutePath,
+{{ " "|repeat(lib_private_fun_indent) }}            )
+{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.getInstance(
+{{ " "|repeat(lib_private_fun_indent) }}                dependency,
+{{ " "|repeat(lib_private_fun_indent) }}                nilClasspathClassLoader,
+{{ " "|repeat(lib_private_fun_indent) }}            )
+{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: UnsatisfiedLinkError) {
+{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringJnaHandling.add(dependency)
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    // Lastly, if all the logic above fails, try loading the library using JNA.
+{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependenciesRequiringJnaHandling) {
+{{ " "|repeat(lib_private_fun_indent) }}        com.sun.jna.NativeLibrary.getInstance(dependency)
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+
+{{ " "|repeat(lib_private_fun_indent) }}private fun findLibraryInClassPath(
+{{ " "|repeat(lib_private_fun_indent) }}    library: String,
+{{ " "|repeat(lib_private_fun_indent) }}    classLoader: ClassLoader,
+{{ " "|repeat(lib_private_fun_indent) }}    extractionDestination: java.io.File,
+{{ " "|repeat(lib_private_fun_indent) }}): java.io.File? {
+{{ " "|repeat(lib_private_fun_indent) }}    var libraryName = System.mapLibraryName(library)
+{{ " "|repeat(lib_private_fun_indent) }}    if (com.sun.jna.Platform.isMac()) {
+{{ " "|repeat(lib_private_fun_indent) }}        if (libraryName.endsWith(".jnilib")) {
+{{ " "|repeat(lib_private_fun_indent) }}            libraryName = libraryName.removeSuffix(".jnilib") + ".dylib"
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    val resourcePath = "${com.sun.jna.Platform.RESOURCE_PREFIX}/$libraryName"
+{{ " "|repeat(lib_private_fun_indent) }}    var url = classLoader.getResource(resourcePath)
+{{ " "|repeat(lib_private_fun_indent) }}    if (com.sun.jna.Platform.isMac() && url == null) {
+{{ " "|repeat(lib_private_fun_indent) }}        url = classLoader.getResource("darwin/$libraryName")
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    if (url == null) {
+{{ " "|repeat(lib_private_fun_indent) }}        url = classLoader.getResource(libraryName)
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    if (url == null) {
+{{ " "|repeat(lib_private_fun_indent) }}        return null
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    if (url.protocol.equals("file", ignoreCase = true)) {
+{{ " "|repeat(lib_private_fun_indent) }}        val file = try {
+{{ " "|repeat(lib_private_fun_indent) }}            java.io.File(url.toURI())
+{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: java.net.URISyntaxException) {
+{{ " "|repeat(lib_private_fun_indent) }}            java.io.File(url.path)
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}        return file.takeIf { it.exists() }
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    val destination = extractionDestination.resolve(resourcePath).apply {
+{{ " "|repeat(lib_private_fun_indent) }}        parentFile?.mkdirs()
+{{ " "|repeat(lib_private_fun_indent) }}        deleteOnExit()
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    url.openStream().use { inputStream ->
+{{ " "|repeat(lib_private_fun_indent) }}        destination.outputStream().use { outputStream ->
+{{ " "|repeat(lib_private_fun_indent) }}            inputStream.copyTo(outputStream)
+{{ " "|repeat(lib_private_fun_indent) }}        }
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}    return destination
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+                                        {%- else %}
+{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
+{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
+{{ " "|repeat(lib_private_fun_indent) }}        com.sun.jna.NativeLibrary.getInstance(dependency)
+{{ " "|repeat(lib_private_fun_indent) }}    }
+{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
+                                        {%- endif %}
+                                        {%- endif %}
+
+    {%- if config.enable_jna_interface_mapping() %}
     }
     {%- endif %}
 
     {%- for func in ci.iter_ffi_function_definitions_excluding_integrity_checks() %}
+    {%- if config.enable_jna_interface_mapping() %}
+    fun
+    {%- else %}
     @JvmStatic
-    external fun {{ func.name() }}(
+    external fun
+    {%- endif %} {{ func.name() }}(
         {%- call kt::arg_list_ffi_decl(func, 8) %}
     ): {% match func.return_type() %}{% when Some(return_type) %}{{ return_type.borrow()|ffi_type_name_by_value(ci) }}{% when None %}Unit{% endmatch %}
     {%- endfor %}

--- a/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
+++ b/crates/gobley-uniffi-bindgen/src/templates/android+jvm/NamespaceLibraryTemplate.kt
@@ -78,6 +78,118 @@ private inline fun <reified Lib : Library> loadIndirect(componentName: String): 
 }
 {%- endif %}
 
+{%- if !dynamic_library_dependencies.is_empty() %}
+{%- if module_name == "jvm" %}
+// Dynamic library dependency loading code.
+//
+// Load dynamic libraries that the main Rust library depends on. They may
+// reside inside a .jar file, or already be installed in the file system.
+// The reason for this custom handling is that JNA copies the extracted
+// library to a temporary file with a random name, resulting in a dynamic
+// link error on Windows. This logic ensures that the destination temporary
+// file has the same base name as the original library file in the JAR file.
+//
+// First, try loading the library without searching the directories
+// specified in CLASSPATH.
+@Suppress("SameParameterValue")
+private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
+    val nilClasspathClassLoader = java.net.URLClassLoader(emptyArray(), Any::class.java.classLoader)
+    val dependenciesRequiringExtraction = mutableListOf<String>()
+    for (dependency in dependencies) {
+        try {
+            com.sun.jna.NativeLibrary.getInstance(dependency, nilClasspathClassLoader)
+        } catch (_: UnsatisfiedLinkError) {
+            dependenciesRequiringExtraction.add(dependency)
+        }
+    }
+    loadDynamicLibraryDependenciesByExtraction(dependenciesRequiringExtraction, nilClasspathClassLoader)
+{{ '}' }}
+
+// Second, try extracting the library from a .jar file.
+private fun loadDynamicLibraryDependenciesByExtraction(
+    dependencies: List<String>,
+    nilClasspathClassLoader: ClassLoader,
+) {
+    if (dependencies.isEmpty()) return
+    // The directory where the dynamic library dependencies in zipped JAR files will be extracted
+    val extractionDestination = java.nio.file.Files.createTempDirectory("gobley-jna").toFile()
+    val classLoader = UniffiLib::class.java.classLoader!!
+    val dependenciesRequiringJnaHandling = mutableListOf<String>()
+    for (dependency in dependencies) {
+        val libraryFile = findLibraryInClassPath(dependency, classLoader, extractionDestination)
+        if (libraryFile == null) {
+            dependenciesRequiringJnaHandling.add(dependency)
+            continue
+        }
+        try {
+            com.sun.jna.NativeLibrary.addSearchPath(
+                dependency,
+                libraryFile.parentFile.absolutePath,
+            )
+            com.sun.jna.NativeLibrary.getInstance(
+                dependency,
+                nilClasspathClassLoader,
+            )
+        } catch (_: UnsatisfiedLinkError) {
+            dependenciesRequiringJnaHandling.add(dependency)
+        }
+    }
+    // Lastly, if all the logic above fails, try loading the library using JNA.
+    for (dependency in dependenciesRequiringJnaHandling) {
+        com.sun.jna.NativeLibrary.getInstance(dependency)
+    }
+{{ '}' }}
+
+private fun findLibraryInClassPath(
+    library: String,
+    classLoader: ClassLoader,
+    extractionDestination: java.io.File,
+): java.io.File? {
+    var libraryName = System.mapLibraryName(library)
+    if (com.sun.jna.Platform.isMac()) {
+        if (libraryName.endsWith(".jnilib")) {
+            libraryName = libraryName.removeSuffix(".jnilib") + ".dylib"
+        }
+    }
+    val resourcePath = "${com.sun.jna.Platform.RESOURCE_PREFIX}/$libraryName"
+    var url = classLoader.getResource(resourcePath)
+    if (com.sun.jna.Platform.isMac() && url == null) {
+        url = classLoader.getResource("darwin/$libraryName")
+    }
+    if (url == null) {
+        url = classLoader.getResource(libraryName)
+    }
+    if (url == null) {
+        return null
+    }
+    if (url.protocol.equals("file", ignoreCase = true)) {
+        val file = try {
+            java.io.File(url.toURI())
+        } catch (_: java.net.URISyntaxException) {
+            java.io.File(url.path)
+        }
+        return file.takeIf { it.exists() }
+    }
+    val destination = extractionDestination.resolve(resourcePath).apply {
+        parentFile?.mkdirs()
+        deleteOnExit()
+    }
+    url.openStream().use { inputStream ->
+        destination.outputStream().use { outputStream ->
+            inputStream.copyTo(outputStream)
+        }
+    }
+    return destination
+{{ '}' }}
+{%- else %}
+private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
+    for (dependency in dependencies) {
+        com.sun.jna.NativeLibrary.getInstance(dependency)
+    }
+{{ '}' }}
+{%- endif %}
+{%- endif %}
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -155,8 +267,8 @@ internal object IntegrityCheckingUniffiLib : Library {
 // This is an implementation detail which will be called internally by the public API.
 {%- if config.enable_jna_interface_mapping() %}
 internal interface UniffiLib : Library {
-    companion object : UniffiLib by loadIndirect("{{ ci.namespace() }}") {
-        init {
+    companion object : UniffiLib by (
+        run {
             {%- if !dynamic_library_dependencies.is_empty() %}
             loadDynamicLibraryDependencies(
                 {%- for dynamic_library in config.dynamic_library_dependencies(module_name) %}
@@ -167,6 +279,10 @@ internal interface UniffiLib : Library {
             )
             {%- endif %}
             IntegrityCheckingUniffiLib
+            loadIndirect("{{ ci.namespace() }}")
+        }
+    ) {
+        init {
             // No need to check the contract version and checksums, since 
             // we already did that with `IntegrityCheckingUniffiLib` above.
             {%- for init_fn in self.initialization_fns(ci) %}
@@ -200,118 +316,6 @@ internal object UniffiLib : Library {
 {{ " "|repeat(lib_private_fun_indent) }}internal val CLEANER: UniffiCleaner by lazy {
 {{ " "|repeat(lib_private_fun_indent) }}    UniffiCleaner.create()
 {{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
-                                        {%- endif %}
-
-                                        {%- if !dynamic_library_dependencies.is_empty() %}
-                                        {%- if module_name == "jvm" %}
-{{ " "|repeat(lib_private_fun_indent) }}// Dynamic library dependency loading code.
-{{ " "|repeat(lib_private_fun_indent) }}//
-{{ " "|repeat(lib_private_fun_indent) }}// Load dynamic libraries that the main Rust library depends on. They may
-{{ " "|repeat(lib_private_fun_indent) }}// reside inside a .jar file, or already be installed in the file system.
-{{ " "|repeat(lib_private_fun_indent) }}// The reason for this custom handling is that JNA copies the extracted
-{{ " "|repeat(lib_private_fun_indent) }}// library to a temporary file with a random name, resulting in a dynamic
-{{ " "|repeat(lib_private_fun_indent) }}// link error on Windows. This logic ensures that the destination temporary
-{{ " "|repeat(lib_private_fun_indent) }}// file has the same base name as the original library file in the JAR file.
-{{ " "|repeat(lib_private_fun_indent) }}//
-{{ " "|repeat(lib_private_fun_indent) }}// First, try loading the library without searching the directories
-{{ " "|repeat(lib_private_fun_indent) }}// specified in CLASSPATH.
-{{ " "|repeat(lib_private_fun_indent) }}@Suppress("SameParameterValue")
-{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
-{{ " "|repeat(lib_private_fun_indent) }}    val nilClasspathClassLoader = java.net.URLClassLoader(emptyArray(), Any::class.java.classLoader)
-{{ " "|repeat(lib_private_fun_indent) }}    val dependenciesRequiringExtraction = mutableListOf<String>()
-{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
-{{ " "|repeat(lib_private_fun_indent) }}        try {
-{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.getInstance(dependency, nilClasspathClassLoader)
-{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: UnsatisfiedLinkError) {
-{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringExtraction.add(dependency)
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    loadDynamicLibraryDependenciesByExtraction(dependenciesRequiringExtraction, nilClasspathClassLoader)
-{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
-
-{{ " "|repeat(lib_private_fun_indent) }}// Second, try extracting the library from a .jar file.
-{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependenciesByExtraction(
-{{ " "|repeat(lib_private_fun_indent) }}    dependencies: List<String>,
-{{ " "|repeat(lib_private_fun_indent) }}    nilClasspathClassLoader: ClassLoader,
-{{ " "|repeat(lib_private_fun_indent) }}) {
-{{ " "|repeat(lib_private_fun_indent) }}    if (dependencies.isEmpty()) return
-{{ " "|repeat(lib_private_fun_indent) }}    // The directory where the dynamic library dependencies in zipped JAR files will be extracted
-{{ " "|repeat(lib_private_fun_indent) }}    val extractionDestination = java.nio.file.Files.createTempDirectory("gobley-jna").toFile()
-{{ " "|repeat(lib_private_fun_indent) }}    val classLoader = UniffiLib::class.java.classLoader!!
-{{ " "|repeat(lib_private_fun_indent) }}    val dependenciesRequiringJnaHandling = mutableListOf<String>()
-{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
-{{ " "|repeat(lib_private_fun_indent) }}        val libraryFile = findLibraryInClassPath(dependency, classLoader, extractionDestination)
-{{ " "|repeat(lib_private_fun_indent) }}        if (libraryFile == null) {
-{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringJnaHandling.add(dependency)
-{{ " "|repeat(lib_private_fun_indent) }}            continue
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}        try {
-{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.addSearchPath(
-{{ " "|repeat(lib_private_fun_indent) }}                dependency,
-{{ " "|repeat(lib_private_fun_indent) }}                libraryFile.parentFile.absolutePath,
-{{ " "|repeat(lib_private_fun_indent) }}            )
-{{ " "|repeat(lib_private_fun_indent) }}            com.sun.jna.NativeLibrary.getInstance(
-{{ " "|repeat(lib_private_fun_indent) }}                dependency,
-{{ " "|repeat(lib_private_fun_indent) }}                nilClasspathClassLoader,
-{{ " "|repeat(lib_private_fun_indent) }}            )
-{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: UnsatisfiedLinkError) {
-{{ " "|repeat(lib_private_fun_indent) }}            dependenciesRequiringJnaHandling.add(dependency)
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    // Lastly, if all the logic above fails, try loading the library using JNA.
-{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependenciesRequiringJnaHandling) {
-{{ " "|repeat(lib_private_fun_indent) }}        com.sun.jna.NativeLibrary.getInstance(dependency)
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
-
-{{ " "|repeat(lib_private_fun_indent) }}private fun findLibraryInClassPath(
-{{ " "|repeat(lib_private_fun_indent) }}    library: String,
-{{ " "|repeat(lib_private_fun_indent) }}    classLoader: ClassLoader,
-{{ " "|repeat(lib_private_fun_indent) }}    extractionDestination: java.io.File,
-{{ " "|repeat(lib_private_fun_indent) }}): java.io.File? {
-{{ " "|repeat(lib_private_fun_indent) }}    var libraryName = System.mapLibraryName(library)
-{{ " "|repeat(lib_private_fun_indent) }}    if (com.sun.jna.Platform.isMac()) {
-{{ " "|repeat(lib_private_fun_indent) }}        if (libraryName.endsWith(".jnilib")) {
-{{ " "|repeat(lib_private_fun_indent) }}            libraryName = libraryName.removeSuffix(".jnilib") + ".dylib"
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    val resourcePath = "${com.sun.jna.Platform.RESOURCE_PREFIX}/$libraryName"
-{{ " "|repeat(lib_private_fun_indent) }}    var url = classLoader.getResource(resourcePath)
-{{ " "|repeat(lib_private_fun_indent) }}    if (com.sun.jna.Platform.isMac() && url == null) {
-{{ " "|repeat(lib_private_fun_indent) }}        url = classLoader.getResource("darwin/$libraryName")
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    if (url == null) {
-{{ " "|repeat(lib_private_fun_indent) }}        url = classLoader.getResource(libraryName)
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    if (url == null) {
-{{ " "|repeat(lib_private_fun_indent) }}        return null
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    if (url.protocol.equals("file", ignoreCase = true)) {
-{{ " "|repeat(lib_private_fun_indent) }}        val file = try {
-{{ " "|repeat(lib_private_fun_indent) }}            java.io.File(url.toURI())
-{{ " "|repeat(lib_private_fun_indent) }}        } catch (_: java.net.URISyntaxException) {
-{{ " "|repeat(lib_private_fun_indent) }}            java.io.File(url.path)
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}        return file.takeIf { it.exists() }
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    val destination = extractionDestination.resolve(resourcePath).apply {
-{{ " "|repeat(lib_private_fun_indent) }}        parentFile?.mkdirs()
-{{ " "|repeat(lib_private_fun_indent) }}        deleteOnExit()
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    url.openStream().use { inputStream ->
-{{ " "|repeat(lib_private_fun_indent) }}        destination.outputStream().use { outputStream ->
-{{ " "|repeat(lib_private_fun_indent) }}            inputStream.copyTo(outputStream)
-{{ " "|repeat(lib_private_fun_indent) }}        }
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}    return destination
-{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
-                                        {%- else %}
-{{ " "|repeat(lib_private_fun_indent) }}private fun loadDynamicLibraryDependencies(vararg dependencies: String) {
-{{ " "|repeat(lib_private_fun_indent) }}    for (dependency in dependencies) {
-{{ " "|repeat(lib_private_fun_indent) }}        com.sun.jna.NativeLibrary.getInstance(dependency)
-{{ " "|repeat(lib_private_fun_indent) }}    }
-{{ " "|repeat(lib_private_fun_indent) }}{{ '}' }}
-                                        {%- endif %}
                                         {%- endif %}
 
     {%- if config.enable_jna_interface_mapping() %}


### PR DESCRIPTION
## Changes

#227 changed the bindgen behavior to use JNA direct mapping instead of interface mapping. However, it raises many errors, like #252 or #259, so we need to introduce an option to opt out of it.

- Added a temporary config option, `__enable_jna_interface_mapping`, which makes the bindgen use interface mapping.
- A corresponding Gradle property `enableJnaInterfaceMapping` is added to `BindingsGeneration`, marked with `@InternalGobleyGradleApi`.
- The API will change in 0.4.

## Testing

- Added Gradle property `gobley.projects.uniffiTests.enableJnaInterfaceMapping`.
- Added CI script `uniffi-tests-im.ps1`.
- These will run UniFFI tests with interface mapping enabled.