### PR TITLE
Add missing delay to the GitHub stargazer API re-calling logic in docs

### DIFF
--- a/docs/src/components/NavbarItems/useGitHubStargazersCount.tsx
+++ b/docs/src/components/NavbarItems/useGitHubStargazersCount.tsx
@@ -33,9 +33,10 @@ async function retrieveStargazersCount(repository: string): Promise<number> {
           return stargazersCount;
         }
       }
-    } catch {
-      // Try with a longer interval, but with a 8-second limit.
-      nextRetryInterval = Math.min(nextRetryInterval * 2, 8000);
-    }
+    } catch {}
+    // Wait before re-calling the API.
+    await new Promise((resolve) => setTimeout(resolve, nextRetryInterval));
+    // Try with a longer interval, but with a 32-second limit.
+    nextRetryInterval = Math.min(nextRetryInterval * 2, 32000);
   }
 }


### PR DESCRIPTION
## Changes

- Added missing delay logic to `useGitHubStargazersCount` that re-calls the GitHub stargazer API when it fails.
- Increased the maximum delay amount to 32 seconds.