### PR TITLE
feat(uniffi): add generateAllNamespaces option for library bindings

### DIFF
--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -317,6 +317,7 @@ class UniFfiPlugin : Plugin<Project> {
                 is BindingsGenerationFromLibrary -> {
                     libraryMode.set(true)
                     source.set(bindingsOutputFile)
+                    generateAllNamespaces.set(bindingsGeneration.generateAllNamespaces)
                 }
             }
             dependsOn(cargoBuildTaskForBindings, installBindgen, mergeUniffiConfig)

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/BindingsGeneration.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/dsl/BindingsGeneration.kt
@@ -102,7 +102,14 @@ sealed class BindingsGeneration(internal val project: Project) {
 }
 
 abstract class BindingsGenerationFromLibrary @Inject internal constructor(project: Project) :
-    BindingsGeneration(project)
+    BindingsGeneration(project) {
+    /**
+     * When `true`, generate bindings for all namespaces/crates found in the library,
+     * not just the main crate. This is useful for libraries that re-export types from
+     * multiple crates (like matrix-rust-sdk).
+     */
+    abstract val generateAllNamespaces: Property<Boolean>
+}
 
 abstract class BindingsGenerationFromUdl @Inject internal constructor(project: Project) :
     BindingsGeneration(project) {

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/BuildUniffiBindingsTask.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/tasks/BuildUniffiBindingsTask.kt
@@ -88,6 +88,14 @@ abstract class BuildUniffiBindingsTask : CargoPackageTask() {
     val crateName: Provider<String> = cargoPackage.map { it.libraryCrateName }
 
     /**
+     * When true and in library mode, generate bindings for all namespaces/crates
+     * found in the library, not just the main crate.
+     */
+    @get:Input
+    @get:Optional
+    abstract val generateAllNamespaces: Property<Boolean>
+
+    /**
      * Path to the UDL file, or cdylib if `library-mode` is specified
      */
     @get:InputFile
@@ -137,7 +145,9 @@ abstract class BuildUniffiBindingsTask : CargoPackageTask() {
             if (libraryMode.get()) {
                 arguments("--library")
             }
-            if (crateName.isPresent) {
+            // Only pass --crate if we're not generating all namespaces
+            val shouldGenerateAllNamespaces = generateAllNamespaces.orNull ?: false
+            if (crateName.isPresent && !shouldGenerateAllNamespaces) {
                 arguments("--crate", crateName.get())
             }
             if (formatCode.isPresent && formatCode.get()) {


### PR DESCRIPTION
Add support for generating bindings for all namespaces/crates found in a library, not just the main crate. This is useful for libraries that re-export types from multiple crates.

There is no existing github issue. This is related to https://github.com/gobley/gobley/discussions/276.

There will probably be a second part required, because we discovered that the the cinterop process also needed to consider the multiple namespaces to generate everything correctly. Our application is now running. We came up with these possible approaches:

Solution 1:
Change in gobley to add a new property like additionalNamespaces  and the client can specify the additional namespaces that will be generated. Then in UniFiPlugin.kt  there is this method configureKotlinNativeTarget where cinterops will be registered for the additional namespaces (similar to the workaround we currently have in client). But, the client still needs to list the namespaces in their build.gradle.kts.

```
uniffi {
      generateFromLibrary {
          generateAllNamespaces.set(true)
          additionalNamespaces.addAll("matrix_sdk", "matrix_sdk_base", ...)
      }
  }
```

Solution 2, better for clients but more complex implementation on gobley side:
In rust code of gobley-uniffi-bindgen, add a new --list-namespaces flag to scan the library and output all namespaces namesIn the gradle plugin UniFfiPlugin.kt call this command ( gobley-uniffi-bindgen --list-namespaces) to parse all namespaces, then register cinterops for each discovered namespaceClient doesn't need to add the namespaces as in the previous case.

```
uniffi {
      generateFromLibrary {
          generateAllNamespaces.set(true)  // ← only this
      }
  }

```
## Changes

> Please describe the contributions you made in this PR. If you're going to make
> a huge change, please give us a justification for that.

- Add generateAllNamespaces property to BindingsGenerationFromLibrary
- Wire generateAllNamespaces through UniFfiPlugin to BuildUniffiBindingsTask
- Skip --crate argument when generateAllNamespaces is enabled

## Testing

No testcases have yet been added.

## Issues Fixed

> If you're going to tackle an unreported bug, please file a new issue so we can
> discuss it in detail. If you think the bug is too minor to make a separate
> issue for it, please ignore this field.

Fixes: *#ISSUE NUMBER*
