### PR TITLE
Add Android KMP library backend alongside legacy AGP integration

### DIFF
--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(plugin(libs.plugins.kotlin.multiplatform))
     implementation(plugin(libs.plugins.kotlin.atomicfu))
+    implementation(plugin(libs.plugins.android.library))
 
     implementation(project(":gobley-gradle-uniffi"))
 

--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/CargoPlugin.kt
@@ -31,6 +31,8 @@ import gobley.gradle.cargo.tasks.InstallWasmTransformerTask
 import gobley.gradle.cargo.tasks.RustUpTargetAddTask
 import gobley.gradle.cargo.tasks.RustUpTask
 import gobley.gradle.cargo.utils.register
+import gobley.gradle.kotlin.gobleyPlatformType
+import gobley.gradle.kotlin.isGobleyAndroidTarget
 import gobley.gradle.kotlin.GobleyKotlinExtensionDelegate
 import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustAndroidTarget
@@ -68,6 +70,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
+@OptIn(InternalGobleyGradleApi::class)
 class CargoPlugin : Plugin<Project> {
     companion object {
         internal const val TASK_GROUP = "cargo"
@@ -180,7 +183,7 @@ class CargoPlugin : Plugin<Project> {
     }
 
     private fun KotlinTarget.requiredRustTargets(): List<RustTarget> {
-        return when (platformType) {
+        return when (gobleyPlatformType) {
             KotlinPlatformType.jvm -> {
                 GobleyHost.current.platform.supportedTargets.filterIsInstance<RustJvmTarget>()
             }
@@ -205,13 +208,13 @@ class CargoPlugin : Plugin<Project> {
     @OptIn(InternalGobleyGradleApi::class)
     private fun Project.checkKotlinTargets() {
         val hasWasmTargets =
-            kotlinExtensionDelegate.targets.any { it.platformType == KotlinPlatformType.wasm }
+            kotlinExtensionDelegate.targets.any { it.gobleyPlatformType == KotlinPlatformType.wasm }
         if (hasWasmTargets) {
             project.logger.warn("WASM targets are added, but Gobley does not support WASM targets yet.")
         }
 
         val hasAndroidJvmTargets =
-            kotlinExtensionDelegate.targets.any { it.platformType == KotlinPlatformType.androidJvm }
+            kotlinExtensionDelegate.targets.any { it.gobleyPlatformType == KotlinPlatformType.androidJvm }
         if (hasAndroidJvmTargets && !::androidDelegate.isInitialized) {
             throw GradleException("Android JVM targets are added, but Android Gradle Plugin is not found.")
         }
@@ -221,7 +224,7 @@ class CargoPlugin : Plugin<Project> {
         val requiredCrateTypes = cargoExtension
             .builds
             .flatMap { it.kotlinTargets }
-            .map { it.platformType.requiredCrateType() }
+            .map { it.gobleyPlatformType.requiredCrateType() }
             .distinct()
         val actualCrateTypes = cargoExtension.cargoPackage.get().libraryCrateTypes
         if (!actualCrateTypes.containsAll(requiredCrateTypes)) {
@@ -246,11 +249,12 @@ class CargoPlugin : Plugin<Project> {
 
     private fun Project.configureBuildTasks() {
         val androidTarget = cargoExtension.builds.firstNotNullOfOrNull { build ->
-            build.kotlinTargets.firstNotNullOfOrNull { it as? KotlinAndroidTarget }
+            build.kotlinTargets.firstOrNull { it.isGobleyAndroidTarget }
         }
         val jvmTarget = cargoExtension.builds.firstNotNullOfOrNull { build ->
             build.kotlinTargets.firstOrNull {
-                it is KotlinJvmTarget || it is KotlinWithJavaTarget<*, *>
+                (it is KotlinJvmTarget || it is KotlinWithJavaTarget<*, *>)
+                        && !it.isGobleyAndroidTarget
             }
         }
         val wasmBindgenInstallTask =
@@ -312,7 +316,7 @@ class CargoPlugin : Plugin<Project> {
                 }
             }
             for (kotlinTarget in cargoBuild.kotlinTargets) {
-                when (kotlinTarget.platformType) {
+                when (kotlinTarget.gobleyPlatformType) {
                     KotlinPlatformType.jvm -> {
                         cargoBuild as CargoJvmBuild<*>
                         cargoBuild.variants {
@@ -333,7 +337,7 @@ class CargoPlugin : Plugin<Project> {
                                         kotlinTarget,
                                         // cargoBuild.jvmVariant is checked inside
                                         this,
-                                        kotlinTarget as KotlinAndroidTarget,
+                                        kotlinTarget,
                                     )
                                 }
                             }
@@ -382,7 +386,7 @@ class CargoPlugin : Plugin<Project> {
         // Android local unit tests.
         kotlinTarget: KotlinTarget,
         cargoBuildVariant: CargoJvmBuildVariant<*>,
-        androidTarget: KotlinAndroidTarget?,
+        androidTarget: KotlinTarget?,
     ) {
         val buildTask = cargoBuildVariant.buildTaskProvider
         val checkTask = cargoBuildVariant.checkTaskProvider
@@ -427,7 +431,7 @@ class CargoPlugin : Plugin<Project> {
 
         @OptIn(InternalGobleyGradleApi::class)
         if (
-            kotlinTarget !is KotlinAndroidTarget
+            !kotlinTarget.isGobleyAndroidTarget
             && cargoBuildVariant.embedRustLibrary.get()
             && cargoBuildVariant.variant == cargoBuildVariant.build.jvmVariant.get()
         ) {
@@ -455,7 +459,7 @@ class CargoPlugin : Plugin<Project> {
 
         @OptIn(InternalGobleyGradleApi::class)
         if (
-            kotlinTarget !is KotlinAndroidTarget
+            !kotlinTarget.isGobleyAndroidTarget
             && cargoBuildVariant.embedRustLibrary.get()
             && cargoBuildVariant.variant == cargoBuildVariant.build.jvmPublishingVariant.get()
             && cargoExtension.publishJvmArtifacts.get()
@@ -477,7 +481,12 @@ class CargoPlugin : Plugin<Project> {
         }
 
         @OptIn(InternalGobleyGradleApi::class)
-        if (androidTarget != null && cargoBuildVariant.androidUnitTest.get()) {
+        val shouldConfigureAndroidUnitTestRuntime = when (androidTarget) {
+            null -> false
+            is KotlinAndroidTarget -> true
+            else -> cargoBuildVariant.variant == cargoBuildVariant.build.jvmVariant.get()
+        }
+        if (shouldConfigureAndroidUnitTestRuntime && cargoBuildVariant.androidUnitTest.get()) {
             DependencyUtils.addAndroidUnitTestRuntimeRustLibraryJar(
                 this,
                 cargoBuildVariant.rustTarget,

--- a/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
+++ b/build-logic/gobley-gradle-uniffi/src/main/kotlin/UniFfiPlugin.kt
@@ -15,6 +15,8 @@ import gobley.gradle.cargo.dsl.CargoExtension
 import gobley.gradle.cargo.dsl.CargoJvmBuild
 import gobley.gradle.cargo.dsl.CargoNativeBuild
 import gobley.gradle.kotlin.GobleyKotlinExtensionDelegate
+import gobley.gradle.kotlin.gobleyPlatformType
+import gobley.gradle.kotlin.isGobleyAndroidTarget
 import gobley.gradle.rust.CrateType
 import gobley.gradle.rust.targets.RustTarget
 import gobley.gradle.rust.targets.RustWasmTarget
@@ -48,7 +50,6 @@ import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMetadataTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
@@ -58,6 +59,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 private const val TASK_GROUP = "uniffi"
 
+@OptIn(InternalGobleyGradleApi::class)
 class UniFfiPlugin : Plugin<Project> {
     private lateinit var uniFfiExtension: UniFfiExtension
     private lateinit var bindingsGeneration: BindingsGeneration
@@ -138,13 +140,13 @@ class UniFfiPlugin : Plugin<Project> {
     @OptIn(InternalGobleyGradleApi::class)
     private fun Project.checkKotlinTargets() {
         val hasJsTargets =
-            kotlinExtensionDelegate.targets.any { it.platformType == KotlinPlatformType.js }
+            kotlinExtensionDelegate.targets.any { it.gobleyPlatformType == KotlinPlatformType.js }
         if (hasJsTargets) {
             project.logger.warn("JS targets are added, but the UniFFI plugin does not support JS targets yet.")
         }
 
         val hasWasmTargets =
-            kotlinExtensionDelegate.targets.any { it.platformType == KotlinPlatformType.wasm }
+            kotlinExtensionDelegate.targets.any { it.gobleyPlatformType == KotlinPlatformType.wasm }
         if (hasWasmTargets) {
             project.logger.warn("WASM targets are added, but the UniFFI plugin does not support WASM targets yet.")
         }
@@ -159,7 +161,7 @@ class UniFfiPlugin : Plugin<Project> {
 
             @OptIn(InternalGobleyGradleApi::class)
             val hasJvmTarget = kotlinExtensionDelegate.targets.any {
-                it is KotlinJvmTarget || it is KotlinWithJavaTarget<*, *>
+                (it is KotlinJvmTarget || it is KotlinWithJavaTarget<*, *>) && !it.isGobleyAndroidTarget
             }
 
             val jvmTargetsToBuild = when {
@@ -191,10 +193,10 @@ class UniFfiPlugin : Plugin<Project> {
             ?: throw GradleException("Cargo build for $buildRustTarget not available")
 
         val availableVariants = build.kotlinTargets.flatMap {
-            when (it) {
-                is KotlinJvmTarget, is KotlinWithJavaTarget<*, *> -> listOf((build as CargoJvmBuild<*>).jvmVariant.get())
-                is KotlinAndroidTarget -> Variant.values().toList()
-                is KotlinNativeTarget -> listOf((build as CargoNativeBuild<*>).nativeVariant.get())
+            when (it.gobleyPlatformType) {
+                KotlinPlatformType.jvm -> listOf((build as CargoJvmBuild<*>).jvmVariant.get())
+                KotlinPlatformType.androidJvm -> Variant.values().toList()
+                KotlinPlatformType.native -> listOf((build as CargoNativeBuild<*>).nativeVariant.get())
                 else -> emptyList<Variant>()
             }
         }.distinct()
@@ -253,11 +255,11 @@ class UniFfiPlugin : Plugin<Project> {
             @OptIn(InternalGobleyGradleApi::class)
             kotlinTargets.set(
                 kotlinExtensionDelegate.targets.mapNotNull {
-                    when (it) {
-                        is KotlinMetadataTarget -> null
-                        is KotlinJvmTarget, is KotlinWithJavaTarget<*, *> -> "jvm"
-                        is KotlinAndroidTarget -> "android"
-                        is KotlinNativeTarget -> "native"
+                    when {
+                        it is KotlinMetadataTarget -> null
+                        it.gobleyPlatformType == KotlinPlatformType.jvm -> "jvm"
+                        it.gobleyPlatformType == KotlinPlatformType.androidJvm -> "android"
+                        it is KotlinNativeTarget -> "native"
                         else -> "stub"
                     }
                 }
@@ -387,23 +389,23 @@ class UniFfiPlugin : Plugin<Project> {
 
         @OptIn(InternalGobleyGradleApi::class)
         kotlinExtensionDelegate.targets.configureEach {
-            when (this) {
-                is KotlinMetadataTarget -> configureKotlinCommonTarget()
-                is KotlinJvmTarget, is KotlinWithJavaTarget<*, *> -> {
+            when {
+                this is KotlinMetadataTarget -> configureKotlinCommonTarget()
+                gobleyPlatformType == KotlinPlatformType.jvm -> {
                     if (kotlinExtensionDelegate.pluginId == PluginIds.KOTLIN_JVM) {
                         configureKotlinCommonTarget()
                     }
                     configureKotlinJvmTarget()
                 }
 
-                is KotlinAndroidTarget -> {
+                gobleyPlatformType == KotlinPlatformType.androidJvm -> {
                     if (kotlinExtensionDelegate.pluginId == PluginIds.KOTLIN_ANDROID) {
                         configureKotlinCommonTarget()
                     }
                     configureKotlinAndroidTarget()
                 }
 
-                is KotlinNativeTarget -> configureKotlinNativeTarget(
+                this is KotlinNativeTarget -> configureKotlinNativeTarget(
                     this,
                     dummyDefFile,
                     generateDummyDefFileTask,

--- a/build-logic/gobley-gradle/build.gradle.kts
+++ b/build-logic/gobley-gradle/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     compileOnly(plugin(libs.plugins.kotlin.multiplatform))
     compileOnly(plugin(libs.plugins.android.application))
     compileOnly(plugin(libs.plugins.android.library))
+    compileOnly(plugin(libs.plugins.android.kotlin.multiplatform.library))
 
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.semver)
@@ -82,6 +83,7 @@ buildConfig {
         buildConfigField("String", "KOTLIN_SERIALIZATION", "\"${libs.plugins.kotlin.serialization.get().pluginId}\"")
         buildConfigField("String", "ANDROID_APPLICATION", "\"${libs.plugins.android.application.get().pluginId}\"")
         buildConfigField("String", "ANDROID_LIBRARY", "\"${libs.plugins.android.library.get().pluginId}\"")
+        buildConfigField("String", "ANDROID_KOTLIN_MULTIPLATFORM_LIBRARY", "\"${libs.plugins.android.kotlin.multiplatform.library.get().pluginId}\"")
         buildConfigField("String", "GOBLEY_RUST", "\"dev.gobley.rust\"")
         buildConfigField("String", "GOBLEY_CARGO", "\"dev.gobley.cargo\"")
         buildConfigField("String", "GOBLEY_UNIFFI", "\"dev.gobley.uniffi\"")

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidBaseExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidBaseExtensionDelegate.kt
@@ -1,0 +1,127 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.android
+
+import com.android.build.api.dsl.ApplicationBuildType
+import com.android.build.api.dsl.BuildType
+import com.android.build.api.dsl.LibraryBuildType
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
+import com.android.build.gradle.internal.tasks.ExtractProguardFiles
+import com.android.build.gradle.internal.tasks.MergeConsumerProguardFilesTask
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import gobley.gradle.InternalGobleyGradleApi
+import gobley.gradle.Variant
+import gobley.gradle.getByVariant
+import gobley.gradle.variant
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import java.io.File
+
+@OptIn(InternalGobleyGradleApi::class)
+class GobleyAndroidBaseExtensionDelegate(
+    private val androidExtension: BaseExtension,
+) : GobleyAndroidExtensionDelegate {
+    constructor(project: Project) : this(project.extensions.getByType<BaseExtension>())
+
+    override val androidSdkRoot: File
+        get() = androidExtension.sdkDirectory
+
+    // TODO: Read <uses-sdk> from AndroidManifest.xml
+    // androidExtension.sourceSets.getByName("main").manifest.srcFile
+    override val androidMinSdk: Int
+        get() = androidExtension.defaultConfig.minSdk ?: 21
+    override val androidNdkRoot: File?
+        get() = androidExtension.ndkPath?.let(::File)
+    override val androidNdkVersion: String?
+        get() = androidExtension.ndkVersion.takeIf(String::isNotEmpty)
+    override val abiFilters: Set<String>
+        get() = androidExtension.defaultConfig.ndk.abiFilters
+
+    override fun addMainSourceDir(
+        variant: Variant?,
+        sourceDirectory: Provider<Directory>,
+    ) {
+        androidExtension.sourceSets { sourceSets ->
+            val sourceSet = if (variant != null) {
+                sourceSets.getByVariant(variant)
+            } else {
+                sourceSets.getByName("main")
+            }
+            sourceSet.java.srcDir(sourceDirectory)
+        }
+    }
+
+    override fun addMainJniDir(
+        project: Project,
+        variant: Variant,
+        jniTask: TaskProvider<*>,
+        jniDirectory: Provider<Directory>
+    ) {
+        project.tasks.withType<MergeSourceSetFolders> {
+            if (name.lowercase().contains("jni") && this.variant == variant) {
+                inputs.dir(jniDirectory)
+                dependsOn(jniTask)
+            }
+        }
+
+        androidExtension.sourceSets { sourceSets ->
+            sourceSets.getByVariant(variant).jniLibs.srcDir(jniDirectory)
+        }
+    }
+
+    override fun addProguardFiles(
+        project: Project,
+        proguardFile: RegularFile,
+        generationTask: TaskProvider<*>,
+    ) {
+        androidExtension.buildTypes.configureEach { buildType ->
+            addProguardFilesToBuildType(project, proguardFile, buildType, generationTask)
+        }
+    }
+
+    private fun addProguardFilesToBuildType(
+        project: Project,
+        proguardFile: RegularFile,
+        buildType: BuildType,
+        generationTask: TaskProvider<*>,
+    ) {
+        // For some reason, androidExtension.buildTypes.getByName returns an internal BuildType
+        // that implements both ApplicationBuildType and LibraryBuildType.
+        if (buildType is ApplicationBuildType) {
+            buildType.proguardFile(proguardFile)
+        }
+        if (buildType is LibraryBuildType) {
+            buildType.consumerProguardFile(proguardFile)
+        }
+
+        project.tasks.withType<ExtractProguardFiles> {
+            dependsOn(generationTask)
+        }
+        project.tasks.withType<AndroidLintAnalysisTask> {
+            if (name.lowercase().contains(buildType.name.lowercase())) {
+                dependsOn(generationTask)
+            }
+        }
+        project.tasks.withType<MergeConsumerProguardFilesTask> {
+            if (name.lowercase().contains(buildType.name.lowercase())) {
+                dependsOn(generationTask)
+            }
+        }
+        project.tasks.withType<LintModelWriterTask> {
+            if (name.lowercase().contains(buildType.name.lowercase())) {
+                dependsOn(generationTask)
+            }
+        }
+    }
+}

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidExtensionDelegate.kt
@@ -6,26 +6,13 @@
 
 package gobley.gradle.android
 
-import com.android.build.api.dsl.ApplicationBuildType
-import com.android.build.api.dsl.BuildType
-import com.android.build.api.dsl.LibraryBuildType
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
-import com.android.build.gradle.internal.lint.LintModelWriterTask
-import com.android.build.gradle.internal.tasks.ExtractProguardFiles
-import com.android.build.gradle.internal.tasks.MergeConsumerProguardFilesTask
-import com.android.build.gradle.tasks.MergeSourceSetFolders
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.Variant
-import gobley.gradle.getByVariant
-import gobley.gradle.variant
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.withType
 import java.io.File
 
 @InternalGobleyGradleApi
@@ -53,116 +40,4 @@ interface GobleyAndroidExtensionDelegate {
         proguardFile: RegularFile,
         generationTask: TaskProvider<*>,
     )
-}
-
-@InternalGobleyGradleApi
-fun GobleyAndroidExtensionDelegate(project: Project): GobleyAndroidExtensionDelegate {
-    return GobleyAndroidExtensionDelegateImpl(project)
-}
-
-@OptIn(InternalGobleyGradleApi::class)
-private class GobleyAndroidExtensionDelegateImpl(project: Project) :
-    GobleyAndroidExtensionDelegate {
-    private val androidExtension: BaseExtension = project.extensions.getByType()
-
-    override val androidSdkRoot: File
-        get() = androidExtension.sdkDirectory
-
-    // TODO: Read <uses-sdk> from AndroidManifest.xml
-    // androidExtension.sourceSets.getByName("main").manifest.srcFile
-    override val androidMinSdk: Int
-        get() = androidExtension.defaultConfig.minSdk ?: 21
-    override val androidNdkRoot: File?
-        get() = androidExtension.ndkPath?.let(::File)
-    override val androidNdkVersion: String?
-        get() = androidExtension.ndkVersion.takeIf(String::isNotEmpty)
-    override val abiFilters: Set<String>
-        get() = androidExtension.defaultConfig.ndk.abiFilters
-
-    override fun addMainSourceDir(
-        variant: Variant?,
-        sourceDirectory: Provider<Directory>,
-    ) {
-        androidExtension.sourceSets { sourceSets ->
-            val testSourceSet = if (variant != null) {
-                sourceSets.getByVariant(variant)
-            } else {
-                sourceSets.getByName("main")
-            }
-            testSourceSet.java.srcDir(sourceDirectory)
-        }
-    }
-
-    override fun addMainJniDir(
-        project: Project,
-        variant: Variant,
-        jniTask: TaskProvider<*>,
-        jniDirectory: Provider<Directory>
-    ) {
-        project.tasks.withType<MergeSourceSetFolders> {
-            if (name.lowercase().contains("jni")) {
-                if (variant == this.variant!!) {
-                    inputs.dir(jniDirectory)
-                    dependsOn(jniTask)
-                }
-            }
-        }
-
-        androidExtension.sourceSets { sourceSets ->
-            val mainSourceSet = sourceSets.getByVariant(variant)
-            mainSourceSet.jniLibs.srcDir(jniDirectory)
-        }
-    }
-
-    override fun addProguardFiles(
-        project: Project,
-        proguardFile: RegularFile,
-        generationTask: TaskProvider<*>,
-    ) {
-        androidExtension.buildTypes.configureEach { buildType ->
-            addProguardFilesToBuildType(project, proguardFile, buildType, generationTask)
-        }
-    }
-
-    private fun addProguardFilesToBuildType(
-        project: Project,
-        proguardFile: RegularFile,
-        buildType: BuildType,
-        generationTask: TaskProvider<*>,
-    ) {
-        // For some reason, androidExtension.buildTypes.getByName returns a internal BuildType
-        // that implements both ApplicationBuildType and LibraryBuildType.
-
-        if (buildType is ApplicationBuildType) {
-            buildType.proguardFile(proguardFile)
-        }
-
-        // extractProguardFiles
-        project.tasks.withType<ExtractProguardFiles> {
-            dependsOn(generationTask)
-        }
-        // lintVitalAnalyze<variant>
-        project.tasks.withType<AndroidLintAnalysisTask> {
-            if (name.lowercase().contains(buildType.name.lowercase())) {
-                dependsOn(generationTask)
-            }
-        }
-
-        if (buildType is LibraryBuildType) {
-            buildType.consumerProguardFile(proguardFile)
-        }
-
-        // merge<variant>ConsumerProguardFiles
-        project.tasks.withType<MergeConsumerProguardFilesTask> {
-            if (name.lowercase().contains(buildType.name.lowercase())) {
-                dependsOn(generationTask)
-            }
-        }
-        // generate<variant>LintModel
-        project.tasks.withType<LintModelWriterTask> {
-            if (name.lowercase().contains(buildType.name.lowercase())) {
-                dependsOn(generationTask)
-            }
-        }
-    }
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidKotlinMultiplatformExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/android/GobleyAndroidKotlinMultiplatformExtensionDelegate.kt
@@ -1,0 +1,142 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.android
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidTarget
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
+import com.android.build.gradle.internal.tasks.ExtractProguardFiles
+import com.android.build.gradle.internal.tasks.MergeConsumerProguardFilesTask
+import com.android.build.gradle.internal.tasks.MergeNativeLibsTask
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import gobley.gradle.InternalGobleyGradleApi
+import gobley.gradle.Variant
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import java.io.File
+import java.util.Properties
+
+@OptIn(InternalGobleyGradleApi::class)
+@Suppress("UnstableApiUsage")
+class GobleyAndroidKotlinMultiplatformExtensionDelegate(
+    private val project: Project,
+    private val kotlinMultiplatformExtension: KotlinMultiplatformExtension,
+) : GobleyAndroidExtensionDelegate {
+    constructor(project: Project) : this(project, project.extensions.getByType<KotlinMultiplatformExtension>())
+
+    private val androidTarget: KotlinMultiplatformAndroidTarget by lazy {
+        val extensionAware = kotlinMultiplatformExtension as ExtensionAware
+        extensionAware.extensions.findByType(KotlinMultiplatformAndroidTarget::class.java)
+            ?: error("Kotlin Multiplatform Android target not found")
+    }
+
+    override val androidSdkRoot: File
+        get() = project.findAndroidSdkRoot()
+            ?: throw IllegalStateException(
+                "Android SDK location not found. Set `sdk.dir` in local.properties or define " +
+                        "`ANDROID_HOME`/`ANDROID_SDK_ROOT`."
+            )
+    override val androidMinSdk: Int
+        get() = androidTarget.minSdk ?: 21
+    override val androidNdkRoot: File?
+        get() = null
+    override val androidNdkVersion: String?
+        get() = null
+    override val abiFilters: Set<String>
+        get() = emptySet()
+
+    override fun addMainSourceDir(
+        variant: Variant?,
+        sourceDirectory: Provider<Directory>,
+    ) {
+        val sourceSetName = when (variant) {
+            Variant.Debug, Variant.Release -> "androidMain"
+            null -> "androidMain"
+        }
+        kotlinMultiplatformExtension.sourceSets
+            .findByName(sourceSetName)
+            ?.kotlin
+            ?.srcDir(sourceDirectory)
+    }
+
+    override fun addMainJniDir(
+        project: Project,
+        variant: Variant,
+        jniTask: TaskProvider<*>,
+        jniDirectory: Provider<Directory>,
+    ) {
+        val variantName = variant.name.lowercase()
+        project.tasks.withType<MergeNativeLibsTask> {
+            if (name.lowercase().contains(variantName)) {
+                inputs.dir(jniDirectory)
+                dependsOn(jniTask)
+            }
+        }
+        project.tasks.withType<MergeSourceSetFolders> {
+            val normalizedName = name.lowercase()
+            if ((normalizedName.contains("jni") || normalizedName.contains("nativelibs"))
+                && normalizedName.contains(variantName)
+            ) {
+                inputs.dir(jniDirectory)
+                dependsOn(jniTask)
+            }
+        }
+    }
+
+    override fun addProguardFiles(
+        project: Project,
+        proguardFile: RegularFile,
+        generationTask: TaskProvider<*>,
+    ) {
+        val optimization = androidTarget.optimization
+        optimization.keepRules.file(proguardFile.asFile)
+        optimization.testKeepRules.file(proguardFile.asFile)
+        optimization.consumerKeepRules.file(proguardFile.asFile)
+        optimization.consumerKeepRules.publish = true
+
+        project.tasks.withType<ExtractProguardFiles> {
+            dependsOn(generationTask)
+        }
+        project.tasks.withType<AndroidLintAnalysisTask> {
+            dependsOn(generationTask)
+        }
+        project.tasks.withType<MergeConsumerProguardFilesTask> {
+            dependsOn(generationTask)
+        }
+        project.tasks.withType<LintModelWriterTask> {
+            dependsOn(generationTask)
+        }
+    }
+}
+
+private fun Project.findAndroidSdkRoot(): File? {
+    val sdkFromProperties = rootProject.file("local.properties")
+        .takeIf(File::exists)
+        ?.inputStream()
+        ?.use { input ->
+            Properties().apply { load(input) }.getProperty("sdk.dir")
+        }
+        ?.takeIf(String::isNotBlank)
+        ?.let(::File)
+        ?.takeIf(File::exists)
+    if (sdkFromProperties != null) {
+        return sdkFromProperties
+    }
+
+    return sequenceOf("ANDROID_HOME", "ANDROID_SDK_ROOT")
+        .mapNotNull(System::getenv)
+        .filter(String::isNotBlank)
+        .map(::File)
+        .firstOrNull(File::exists)
+}

--- a/build-logic/gobley-gradle/src/main/kotlin/kotlin/GobleyKotlinMultiplatformExtensionDelegate.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/kotlin/GobleyKotlinMultiplatformExtensionDelegate.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.targets.js.KotlinWasmTargetType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
@@ -48,7 +47,7 @@ class GobleyKotlinMultiplatformExtensionDelegate(
         get() = targets.firstOrNull { it is KotlinJvmTarget }
 
     override val androidTarget: KotlinTarget?
-        get() = targets.firstOrNull { it is KotlinAndroidTarget }
+        get() = targets.firstOrNull { it.isGobleyAndroidTarget }
 }
 
 @OptIn(InternalGobleyGradleApi::class)
@@ -62,30 +61,25 @@ private fun GobleyKotlinSourceSetCollection(
         override val commonMain: KotlinSourceSet
             get() = sourceSets.getByName("commonMain")
 
-        private fun androidTarget(): KotlinAndroidTarget {
-            return targets.filterIsInstance<KotlinAndroidTarget>().firstOrNull()
-                ?: error("Android target not present")
-        }
-
         override fun androidMain(variant: Variant?): KotlinSourceSet {
-            val androidTarget = androidTarget()
-            return sourceSets.maybeCreate(
+            return sourceSets.findAndroidSourceSet(
                 when (variant) {
-                    Variant.Debug -> "${androidTarget.name}Debug"
-                    Variant.Release -> "${androidTarget.name}Release"
-                    null -> "androidMain"
-                }
+                    Variant.Debug -> listOf("androidDebug", "androidMain")
+                    Variant.Release -> listOf("androidRelease", "androidMain")
+                    null -> listOf("androidMain")
+                },
+                fallbackName = "androidMain",
             )
         }
 
         override fun androidUnitTest(variant: Variant?): KotlinSourceSet {
-            val androidTarget = androidTarget()
-            return sourceSets.maybeCreate(
+            return sourceSets.findAndroidSourceSet(
                 when (variant) {
-                    Variant.Debug -> "${androidTarget.name}UnitTestDebug"
-                    Variant.Release -> "${androidTarget.name}UnitTestRelease"
-                    null -> "${androidTarget.name}UnitTest"
-                }
+                    Variant.Debug -> listOf("androidUnitTestDebug", "androidUnitTest", "androidTestOnJvm")
+                    Variant.Release -> listOf("androidUnitTestRelease", "androidUnitTest", "androidTestOnJvm")
+                    null -> listOf("androidUnitTest", "androidTestOnJvm")
+                },
+                fallbackName = "androidTestOnJvm",
             )
         }
 
@@ -133,4 +127,14 @@ private fun GobleyKotlinSourceSetCollection(
                 wasmTarget(KotlinWasmTargetType.WASI)
             }
     }
+}
+
+private fun NamedDomainObjectContainer<KotlinSourceSet>.findAndroidSourceSet(
+    names: List<String>,
+    fallbackName: String,
+): KotlinSourceSet {
+    for (name in names) {
+        findByName(name)?.let { return it }
+    }
+    return maybeCreate(fallbackName)
 }

--- a/build-logic/gobley-gradle/src/main/kotlin/kotlin/KotlinTargetPlatformUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/kotlin/KotlinTargetPlatformUtils.kt
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package gobley.gradle.kotlin
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidTarget
+import gobley.gradle.InternalGobleyGradleApi
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+
+@InternalGobleyGradleApi
+val KotlinTarget.gobleyPlatformType: KotlinPlatformType
+    get() = when {
+        this is KotlinMultiplatformAndroidTarget -> KotlinPlatformType.androidJvm
+        else -> platformType
+    }
+
+@InternalGobleyGradleApi
+val KotlinTarget.isGobleyAndroidTarget: Boolean
+    get() = gobleyPlatformType == KotlinPlatformType.androidJvm

--- a/build-logic/gobley-gradle/src/main/kotlin/utils/PluginUtils.kt
+++ b/build-logic/gobley-gradle/src/main/kotlin/utils/PluginUtils.kt
@@ -8,14 +8,14 @@ package gobley.gradle.utils
 
 import gobley.gradle.InternalGobleyGradleApi
 import gobley.gradle.PluginIds
+import gobley.gradle.android.GobleyAndroidBaseExtensionDelegate
 import gobley.gradle.android.GobleyAndroidExtensionDelegate
+import gobley.gradle.android.GobleyAndroidKotlinMultiplatformExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinAndroidExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinJvmExtensionDelegate
 import gobley.gradle.kotlin.GobleyKotlinMultiplatformExtensionDelegate
-import gobley.gradle.rust.targets.RustAndroidTarget
 import org.gradle.api.GradleException
-import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 @InternalGobleyGradleApi
@@ -82,10 +82,13 @@ object PluginUtils {
 
     fun withAndroidPlugin(project: Project, action: (GobleyAndroidExtensionDelegate) -> Unit) {
         project.plugins.withId(PluginIds.ANDROID_APPLICATION) {
-            action(GobleyAndroidExtensionDelegate(project))
+            action(GobleyAndroidBaseExtensionDelegate(project))
         }
         project.plugins.withId(PluginIds.ANDROID_LIBRARY) {
-            action(GobleyAndroidExtensionDelegate(project))
+            action(GobleyAndroidBaseExtensionDelegate(project))
+        }
+        project.plugins.withId(PluginIds.ANDROID_KOTLIN_MULTIPLATFORM_LIBRARY) {
+            action(GobleyAndroidKotlinMultiplatformExtensionDelegate(project))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ kotest = "5.9.1"
 
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ fun ExtraPropertiesExtension.propertyIsTrue(propertyName: String, default: Boole
 }
 
 if (ext.propertyIsTrue("gobley.projects.gradleTests")) {
+    include(":tests:gradle:android-kmp-library")
     include(":tests:gradle:android-linking")
     include(":tests:gradle:cargo-only")
     include(":tests:gradle:js-only")

--- a/tests/gradle/android-kmp-library/Cargo.toml
+++ b/tests/gradle/android-kmp-library/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gobley-fixture-gradle-android-kmp-library"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "gobley_fixture_gradle_android_kmp_library"
+crate-type = ["cdylib"]
+path = "src/main/rust/lib.rs"
+
+[dependencies]
+
+[workspace]

--- a/tests/gradle/android-kmp-library/build.gradle.kts
+++ b/tests/gradle/android-kmp-library/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("multiplatform")
+    id("dev.gobley.cargo")
+    alias(libs.plugins.android.kotlin.multiplatform.library)
+}
+
+kotlin {
+    @Suppress("UnstableApiUsage")
+    androidLibrary {
+        namespace = "dev.gobley.tests.gradle.androidkmplibrary"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = 21
+    }
+}

--- a/tests/gradle/android-kmp-library/src/main/rust/lib.rs
+++ b/tests/gradle/android-kmp-library/src/main/rust/lib.rs
@@ -1,0 +1,4 @@
+#[unsafe(no_mangle)]
+pub extern "C" fn gobley_fixture_android_kmp_library_add(a: i32, b: i32) -> i32 {
+    a + b
+}


### PR DESCRIPTION
## Summary
- split Android integration into backend delegates for legacy AGP (`com.android.library`/`com.android.application`) and the Android KMP library plugin (`com.android.kotlin.multiplatform.library`)
- add Kotlin target compatibility mapping so Android KMP targets are treated as Android (`androidJvm`) in Cargo and UniFFI task planning
- update Cargo and UniFFI wiring to avoid JVM/Android target misclassification and variant collisions on Android KMP projects
- add a dedicated Gradle fixture project (`tests:gradle:android-kmp-library`) and include it in gradle test project set

## Verification
- `./gradlew :build-logic:gobley-gradle-cargo:test :build-logic:gobley-gradle-uniffi:test`
- `./gradlew :tests:gradle:android-kmp-library:assemble -Pgobley.projects.examples=false -Pgobley.projects.uniffiTests=false -Pgobley.projects.gradleTests=true`
- `./gradlew :tests:gradle:android-linking:assemble -Pgobley.projects.examples=false -Pgobley.projects.uniffiTests=false -Pgobley.projects.gradleTests=true`
