### PR TITLE
Add `CargoInstallTask.locked`

### DIFF
--- a/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoInstallTask.kt
+++ b/build-logic/gobley-gradle-cargo/src/main/kotlin/tasks/CargoInstallTask.kt
@@ -28,7 +28,6 @@ abstract class CargoInstallTask : CargoTask() {
 
     @get:OutputDirectory
     abstract val installDirectory: DirectoryProperty
-
     protected fun binaryCrateOutput(crateName: String): RegularFileProperty {
         return project.objects.fileProperty()
             .convention(
@@ -37,6 +36,11 @@ abstract class CargoInstallTask : CargoTask() {
                 )
             )
     }
+
+    // TODO: Make this public in the next version
+    @InternalGobleyGradleApi
+    @get:Input
+    internal val locked: Property<Boolean> = project.objects.property<Boolean>().convention(true)
 
     @TaskAction
     fun installBinaries() {
@@ -47,6 +51,10 @@ abstract class CargoInstallTask : CargoTask() {
             if (quiet.get()) {
                 arguments("--quiet")
             }
+            if (locked.get()) {
+                arguments("--locked")
+            }
+
             when (val source = binaryCrateSource.get()) {
                 is CargoBinaryCrateSource.Registry -> {
                     arguments("${source.packageName}@${source.version}")


### PR DESCRIPTION
## Changes

`cargo install` ignores the lock file without the `--locked` flag, which becomes a problem when installing the bindgen when some of the dependencies have published a new version that requires a higher version or edition of Rust.
- Added an internal boolean property `locked` to `CargoInstallTask`, which makes the task install executables with the `--locked` flag.
- This property is set to `true` by default and will be public in the next version.