### PR TITLE
Remove dangling consumerProguardFiles references from examples

### DIFF
--- a/examples/arithmetic-procmacro/build.gradle.kts
+++ b/examples/arithmetic-procmacro/build.gradle.kts
@@ -87,7 +87,6 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
-        consumerProguardFiles("proguard-rules.pro")
         ndk.abiFilters.add("arm64-v8a")
     }
 

--- a/examples/custom-types/build.gradle.kts
+++ b/examples/custom-types/build.gradle.kts
@@ -74,7 +74,6 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
-        consumerProguardFiles("proguard-rules.pro")
         ndk.abiFilters.add("arm64-v8a")
     }
 

--- a/examples/todolist/build.gradle.kts
+++ b/examples/todolist/build.gradle.kts
@@ -90,7 +90,6 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
-        consumerProguardFiles("proguard-rules.pro")
         ndk.abiFilters.add("arm64-v8a")
     }
 


### PR DESCRIPTION
## Changes

`examples/custom-types`, `examples/todolist` and `examples/arithmetic-procmacro` still declare `consumerProguardFiles("proguard-rules.pro")` in `defaultConfig`, but #140 deleted those `proguard-rules.pro` files when the UniFFI plugin took over generating the rules. The declarations have pointed at missing files ever since.

## Testing

`:examples:todolist:assembleRelease` succeeds, and the resulting AAR's `proguard.txt` still carries the rules generated by the UniFFI plugin, so the removed line was contributing nothing.

## Notes

Branched off `main`, independent of #291. Noticed while investigating that one, but unrelated to it.

Drafted with Claude Code and reviewed by me before opening.