### PR TITLE
Update cmake, cc, and find-msvc-tools for Visual Studio 2026

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.104",
 ]
 
@@ -469,12 +469,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -584,9 +584,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -785,9 +785,9 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -2580,6 +2580,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
`Cargo.lock` only: `cmake` 0.1.54 to 0.1.58, `cc` 1.2.41 to 1.4.0, `find-msvc-tools` 0.1.4 to 0.1.9.

## The problem

GitHub repointed `windows-latest` from `windows-2025` to `windows-2025-vs2026`. That image carries Visual Studio 2026 (18.7) and MSBuild 18.7, and no VS 2022. Since then every build that calls cmake from a build script panics with `couldn't determine visual studio generator`. Three Windows jobs have been red on `main` ever since: `cargo-tests`, `gradle-tests`, and `examples-tokio-boring-app`. There are no commits between the last green run and the first red one.

The panic surfaces in the `cmake` crate but the message is written elsewhere:

```
cmake::Config::visual_studio_generator()    cmake 0.1.54, lib.rs:970  <- panics here
  cc::windows_registry::find_vs_version()   cc 1.2.41, lib.rs:321
    find_msvc_tools::find_vs_version()      find-msvc-tools 0.1.4     <- message written here
```

`find-msvc-tools` 0.1.4 knows MSBuild 17.0 down to 14.0. Nothing matches on the new image, so it returns an error and `cmake` re-panics with it.

## Why all three crates

Each is an independent blocker, and a partial bump is worse than none: `cc` 1.2.41 accepts `find-msvc-tools` 0.1.9 under semver and then hits `unreachable!("unknown VS version")` on the `Vs18` it gets back.

| Crate | From | To | Why |
| --- | --- | --- | --- |
| `find-msvc-tools` | 0.1.4 | 0.1.9 | adds `Vs18` and MSBuild 18.0 detection |
| `cc` | 1.2.41 | 1.4.0 | exposes `VsVers::Vs18` |
| `cmake` | 0.1.54 | 0.1.58 | maps `Vs18` to `"Visual Studio 18 2026"` |

`cargo update -p cmake --precise 0.1.58` produces exactly this. Plain `cargo update -p cmake` does nothing, because cargo holds the other locked packages fixed and `cmake` 0.1.55+ needs `cc ^1.2.46`.

## What was ruled out

Running vcvars first does not help. It sets `VisualStudioVersion=18.0`, which 0.1.4 fails to recognise from the environment just as it does from the registry. I confirmed that by running it rather than reasoning about it.

`CMAKE_GENERATOR=Ninja` is worse. `boring-sys` picks its output subdirectory from `target.ends_with("-msvc")` rather than from the generator, so under single-config Ninja the libraries land where none of its link search paths look.

## Testing

Reproduced and fixed locally on macOS first, since `find_vs_version()` reads `VisualStudioVersion` before any Windows-only code. Under `VisualStudioVersion=18.0` the locked versions fail and the new ones return `Ok(Vs18)`; VS 2022 still returns `Ok(Vs17)`. Through the cmake crate, the old versions panic at `lib.rs:970:25`, the same line and column CI reports, and the new ones emit `-G "Visual Studio 18 2026" -Thost=x64 -Ax64`.

Then on a trimmed CI matrix, all three previously red Windows jobs pass, including BoringSSL compiling under the VS 2026 toolchain. `cargo check --workspace --all-targets` is clean with `cc` 1.4.0, covering both cmake consumers.

One thing worth knowing: `gobley-wasm-transformer`'s dependency closure includes `cc`, so this also changes what a future `cargo install --locked` of that tool pins.

No CHANGELOG entry, following the precedent of recent CI and dependency commits (fbaec69, c49e8a9, a4d0a0e, 034cc27). These crates are build dependencies of test fixtures and examples only.

---

Written with AI assistance (Claude Code) and pending human review, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
