### PR TITLE
Stop UniFFI tests depending on wall-clock timing and thread scheduling

### DIFF
--- a/tests/uniffi/coverall-android/src/androidTest/kotlin/CoverallTest.kt
+++ b/tests/uniffi/coverall-android/src/androidTest/kotlin/CoverallTest.kt
@@ -48,6 +48,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
@@ -533,19 +534,31 @@ class CoverallTest {
                 newFixedThreadPoolContext(3, "CoverallTest.threadSafe Thread Pool")
             )
             try {
-                val busyWaiting = coroutineScope.launch {
-                    // 300 ms should be long enough for the other thread to easily finish
-                    // its loop, but not so long as to annoy the user with a slow test.
-                    counter.busyWait(300)
-                }
+                val busyWaitDone = CompletableDeferred<Unit>()
+                val incrementerReady = CompletableDeferred<Unit>()
+
                 val incrementing = coroutineScope.async {
+                    incrementerReady.complete(Unit)
                     var count = 0
-                    for (n in 1..100) {
-                        // We expect most iterations of this loop to run concurrently
-                        // with the busy-waiting thread.
+                    // Keep polling until we actually observe the other thread being busy.
+                    // A fixed iteration count can run to completion before that thread is
+                    // ever scheduled at all on a loaded machine, which made this test flaky.
+                    while (count == 0 && !busyWaitDone.isCompleted) {
                         count = counter.incrementIfBusy()
                     }
                     count
+                }
+                // Only start busy-waiting once the incrementing coroutine is actually
+                // running, so it cannot miss the window by not having started yet.
+                incrementerReady.await()
+                val busyWaiting = coroutineScope.launch {
+                    try {
+                        // 300 ms is long enough for the other thread to observe this one
+                        // as busy, but not so long as to annoy the user with a slow test.
+                        counter.busyWait(300)
+                    } finally {
+                        busyWaitDone.complete(Unit)
+                    }
                 }
 
                 busyWaiting.join()

--- a/tests/uniffi/coverall-android/src/test/kotlin/CoverallTest.kt
+++ b/tests/uniffi/coverall-android/src/test/kotlin/CoverallTest.kt
@@ -48,6 +48,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
@@ -533,19 +534,31 @@ class CoverallTest {
                 newFixedThreadPoolContext(3, "CoverallTest.threadSafe Thread Pool")
             )
             try {
-                val busyWaiting = coroutineScope.launch {
-                    // 300 ms should be long enough for the other thread to easily finish
-                    // its loop, but not so long as to annoy the user with a slow test.
-                    counter.busyWait(300)
-                }
+                val busyWaitDone = CompletableDeferred<Unit>()
+                val incrementerReady = CompletableDeferred<Unit>()
+
                 val incrementing = coroutineScope.async {
+                    incrementerReady.complete(Unit)
                     var count = 0
-                    for (n in 1..100) {
-                        // We expect most iterations of this loop to run concurrently
-                        // with the busy-waiting thread.
+                    // Keep polling until we actually observe the other thread being busy.
+                    // A fixed iteration count can run to completion before that thread is
+                    // ever scheduled at all on a loaded machine, which made this test flaky.
+                    while (count == 0 && !busyWaitDone.isCompleted) {
                         count = counter.incrementIfBusy()
                     }
                     count
+                }
+                // Only start busy-waiting once the incrementing coroutine is actually
+                // running, so it cannot miss the window by not having started yet.
+                incrementerReady.await()
+                val busyWaiting = coroutineScope.launch {
+                    try {
+                        // 300 ms is long enough for the other thread to observe this one
+                        // as busy, but not so long as to annoy the user with a slow test.
+                        counter.busyWait(300)
+                    } finally {
+                        busyWaitDone.complete(Unit)
+                    }
                 }
 
                 busyWaiting.join()

--- a/tests/uniffi/coverall-jvm/src/test/kotlin/CoverallTest.kt
+++ b/tests/uniffi/coverall-jvm/src/test/kotlin/CoverallTest.kt
@@ -48,6 +48,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
@@ -533,19 +534,31 @@ class CoverallTest {
                 newFixedThreadPoolContext(3, "CoverallTest.threadSafe Thread Pool")
             )
             try {
-                val busyWaiting = coroutineScope.launch {
-                    // 300 ms should be long enough for the other thread to easily finish
-                    // its loop, but not so long as to annoy the user with a slow test.
-                    counter.busyWait(300)
-                }
+                val busyWaitDone = CompletableDeferred<Unit>()
+                val incrementerReady = CompletableDeferred<Unit>()
+
                 val incrementing = coroutineScope.async {
+                    incrementerReady.complete(Unit)
                     var count = 0
-                    for (n in 1..100) {
-                        // We expect most iterations of this loop to run concurrently
-                        // with the busy-waiting thread.
+                    // Keep polling until we actually observe the other thread being busy.
+                    // A fixed iteration count can run to completion before that thread is
+                    // ever scheduled at all on a loaded machine, which made this test flaky.
+                    while (count == 0 && !busyWaitDone.isCompleted) {
                         count = counter.incrementIfBusy()
                     }
                     count
+                }
+                // Only start busy-waiting once the incrementing coroutine is actually
+                // running, so it cannot miss the window by not having started yet.
+                incrementerReady.await()
+                val busyWaiting = coroutineScope.launch {
+                    try {
+                        // 300 ms is long enough for the other thread to observe this one
+                        // as busy, but not so long as to annoy the user with a slow test.
+                        counter.busyWait(300)
+                    } finally {
+                        busyWaitDone.complete(Unit)
+                    }
                 }
 
                 busyWaiting.join()

--- a/tests/uniffi/coverall/src/commonTest/kotlin/CoverallTest.kt
+++ b/tests/uniffi/coverall/src/commonTest/kotlin/CoverallTest.kt
@@ -48,6 +48,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -574,19 +575,31 @@ class CoverallTest {
         ThreadsafeCounter().use { counter ->
             val coroutineScope = CoroutineScope(multithreadedCoroutineContext)
             try {
-                val busyWaiting = coroutineScope.launch {
-                    // 1000 ms should be long enough for the other thread to easily finish
-                    // its loop, but not so long as to annoy the user with a slow test.
-                    counter.busyWait(1000)
-                }
+                val busyWaitDone = CompletableDeferred<Unit>()
+                val incrementerReady = CompletableDeferred<Unit>()
+
                 val incrementing = coroutineScope.async {
+                    incrementerReady.complete(Unit)
                     var count = 0
-                    for (n in 1..100) {
-                        // We expect most iterations of this loop to run concurrently
-                        // with the busy-waiting thread.
+                    // Keep polling until we actually observe the other thread being busy.
+                    // A fixed iteration count can run to completion before that thread is
+                    // ever scheduled at all on a loaded machine, which made this test flaky.
+                    while (count == 0 && !busyWaitDone.isCompleted) {
                         count = counter.incrementIfBusy()
                     }
                     count
+                }
+                // Only start busy-waiting once the incrementing coroutine is actually
+                // running, so it cannot miss the window by not having started yet.
+                incrementerReady.await()
+                val busyWaiting = coroutineScope.launch {
+                    try {
+                        // 300 ms is long enough for the other thread to observe this one
+                        // as busy, but not so long as to annoy the user with a slow test.
+                        counter.busyWait(300)
+                    } finally {
+                        busyWaitDone.complete(Unit)
+                    }
                 }
 
                 busyWaiting.join()

--- a/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
+++ b/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
@@ -6,6 +6,7 @@
 
 import futures.*
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import io.kotest.matchers.ranges.beIn
 import io.kotest.matchers.shouldBe
@@ -259,13 +260,28 @@ class FuturesTest {
         newMyRecord("foo", 42u) shouldBe MyRecord("foo", 42u)
     }
 
+    // What this guards is that a waker firing a second time does not corrupt the
+    // future it belongs to, or let a later future complete early.
+    //
+    // Only lower bounds are asserted. An upper bound on the total would also be
+    // measuring per-await timer and FFI overhead, which on a shared CI runner is
+    // large enough to rival the sleeps themselves, and a future that never
+    // completes is already caught by runTest's own timeout.
     @Test
-    fun testBrokenSleep() = assertApproximateTime(500) {
-        brokenSleep(100U, 0U) // calls the waker twice immediately
-        sleep(100U) // wait for possible failure
+    fun testBrokenSleep() = runTest {
+        // Calls the waker a second time immediately.
+        measureTime { brokenSleep(100U, 0U) }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
+        // The stray wake must not have completed this one early.
+        measureTime { sleep(100U) shouldBe true }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
 
-        brokenSleep(100U, 100U) // calls the waker a second time after 1s
-        sleep(200U) // wait for possible failure
+        // Calls the waker a second time 100 ms later, so it lands while the
+        // following sleep is still in flight.
+        measureTime { brokenSleep(100U, 100U) }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
+        measureTime { sleep(200U) shouldBe true }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 195L
     }
 
     @Test

--- a/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
+++ b/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
@@ -13,10 +13,12 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFails
@@ -284,14 +286,20 @@ class FuturesTest {
             .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 195L
     }
 
+    // Cancelling the first task must let the second one acquire the resource. As above,
+    // the detector is useSharedResource throwing AsyncError.Timeout against its own
+    // 1000 ms budget, so there is no wall-clock bound here either.
     @Test
-    fun testFutureWithLockAndCancelled() = assertMaxTime(100) {
+    fun testFutureWithLockAndCancelled() = runTest {
         val job = launch {
             useSharedResource(SharedResourceOptions(releaseAfterMs = 5000U, timeoutMs = 100U))
         }
 
-        // Wait some time to ensure the task has locked the shared resource
-        delay(50)
+        // Wait some time to ensure the task has locked the shared resource. This has to
+        // leave the test scheduler: on its own, delay() runs on runTest's virtual clock
+        // and returns in about 3 ms, so the job got cancelled before it ever took the
+        // lock and the test was not exercising what it describes.
+        withContext(Dispatchers.Default) { delay(50) }
         // Cancel the job before the shared resource has been released.
         job.cancel()
 
@@ -300,9 +308,16 @@ class FuturesTest {
         useSharedResource(SharedResourceOptions(releaseAfterMs = 0U, timeoutMs = 1000U))
     }
 
+    // The first call holds the shared resource for 100 ms, and the second must still be
+    // able to take it afterwards. A resource that never gets released shows up as
+    // useSharedResource throwing AsyncError.Timeout against its own 1000 ms budget, so
+    // that is what actually detects the failure here and only the lower bound is worth
+    // asserting on the clock.
     @Test
-    fun testFutureWithLockButNotCancelled() = assertApproximateTime(100) {
-        useSharedResource(SharedResourceOptions(releaseAfterMs = 100U, timeoutMs = 1000U))
+    fun testFutureWithLockButNotCancelled() = runTest {
+        measureTime {
+            useSharedResource(SharedResourceOptions(releaseAfterMs = 100U, timeoutMs = 1000U))
+        }.inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
         useSharedResource(SharedResourceOptions(releaseAfterMs = 0U, timeoutMs = 1000U))
     }
 }


### PR DESCRIPTION
Four tests across two fixtures assert on wall-clock time or on thread scheduling. All four flake on loaded CI runners, and two of them are failing right now. This replaces those assumptions with ones that hold regardless of how busy the machine is.

None of these are UniFFI bugs. Each test is guarding something real, and each still fails when that real thing breaks.

## CoverallTest.threadSafe

One coroutine busy-waits while another calls `incrementIfBusy` a fixed 100 times, then the test asserts the second one saw the first as busy at least once. Those 100 calls are fast. On a loaded runner they can all finish before the busy-waiting coroutine is scheduled at all, leaving `count` at 0 and failing an assertion about UniFFI locking for reasons that have nothing to do with locking.

It fails on `main` in `uniffi-tests-gir, windows`, and on pull requests whose diffs cannot reach this code.

Poll until the busy window is actually observed instead of counting iterations:

```kotlin
while (count == 0 && !busyWaitDone.isCompleted) {
    count = counter.incrementIfBusy()
}
```

The loop exits as soon as `count` goes above 0, so the normal case still takes microseconds and a starved machine waits as long as it needs to. Busy-waiting starts only once the incrementing side signals it is running, which removes the case where the incrementer had not started at all by the time the window closed. A thread that is running but starved for the whole window could still fail, so this narrows the race rather than closing it.

Serialization is still caught. If UniFFI serialized access to the counter, the first `incrementIfBusy` would block for the entire busy wait and return with `is_busy` already cleared, so `count` stays 0 and the assertion fails.

Four copies of this test exist and all four now match. The one CI reports is `coverall-jvm`. The KMP copy's busy wait is unified from 1000 ms down to 300 ms to match the others, since the duration no longer sets the margin. JS, WASM-JS and WASM-WASI set `uniffiSupported = false` and return before any of this runs, so the loop only executes on the JVM and Native three-thread pools.

## FuturesTest.testBrokenSleep

Nominal 500 ms across four awaits, required to land in [500, 1000]. On the macOS runners it came in at **1001 ms and 1008 ms**, failing by 1 ms and 8 ms. It has been failing since at least 2026-07-22, on `main` as well as on pull requests.

The overhead is structural rather than contention. Each awaited Rust timer spawns a thread and resumes back through the FFI, costing about 5 ms locally and roughly 125 ms per await on a shared macOS runner. `testSleepWithRepeat` shows the same effect independently in the same job: 65 sequential 20 ms sleeps, nominal 1.3 s, actual 6.9 s. Raising the cap only moves the cliff, because that cost has no upper bound on a shared VM.

What the test is for is that a waker firing a second time does not corrupt its own future or let a later one finish early. That is a lower bound, and lower bounds do not care how loaded the machine is: `thread::sleep` is an at-least guarantee and `measureTime` is monotonic. Each step now asserts it took at least as long as it slept, and the upper bound is gone. A future that never completes is still caught by `runTest`'s own timeout.

These bounds are weaker than ones the file already relies on. `assertApproximateTime` asserts an exact nominal lower bound with no slack on eight other tests, on these same platforms.

## FuturesTest.testFutureWithLockButNotCancelled

Next in line to flake: nominal 100 ms, window [100, 600], and CI was already spending 488 ms of it. The upper bound was never the detector. `use_shared_resource` returns `Result<(), AsyncError>` and throws `AsyncError.Timeout` against its own 1000 ms budget if the resource is not released, so the exception is what catches a real fault. Same treatment: keep the lower bound, drop the window.

## FuturesTest.testFutureWithLockAndCancelled

A different problem in the same file. The test launches a job, waits for it to take the lock, then cancels it. That wait was a plain `delay(50)` inside `runTest`, which runs on the virtual clock and returns in about 3 ms, measured. So the job was being cancelled before it ever took the lock, and the test had not been exercising the case it describes. Moving the wait onto `Dispatchers.Default` makes it real, which took the test from 1-15 ms to 68 ms.

Its wall-clock cap is removed rather than widened, for the same reason as its sibling: an unreleased lock surfaces as `AsyncError.Timeout` from the second acquire, and any cap large enough to be safe today is still a cliff on a runner that spent 388 ms of overhead on a single call in this very file.

## Testing

Every change was checked in both directions, because a test that cannot fail is worse than a flaky one.

- `threadSafe`: delaying the busy-waiting coroutine by 200 ms reproduces the CI failure exactly on the old code, `AssertionError at CoverallTest.kt:530`, and passes on the new. Wrapping both calls in a shared lock to stand in for serialized access still fails.
- `testBrokenSleep`: shortening one sleep to simulate a future completing early still trips the new lower bound.
- `testFutureWithLockButNotCancelled`: releasing the shared resource immediately still trips its lower bound.

Locally everything passes on `coverall-jvm:test`, `coverall:jvmTest`, `futures:jvmTest` and `futures:macosArm64Test`, plus both Android variants compile. `threadSafe` also survives six runs under 72 spinners on 12 cores. On CI, `uniffi-tests-gir` passes on both Windows and macOS.

For context on why the futures failures do not reproduce on a laptop: the old `testBrokenSleep` measured 523 ms here unloaded and 524 ms under 96 spinners. Load barely moves it, because the cost is per-await timer and FFI latency on virtualized runners rather than CPU starvation.

## What this gives up

A future that completes late but eventually, say after five seconds, is now caught by `runTest`'s 60 s timeout rather than by a 1000 ms cap. That trade is deliberate.

## Note

The three cmake failures on Windows are a separate problem with a separate fix in #293. Until that lands, this branch's own CI will still show them.

---

Written with AI assistance (Claude Code) and pending human review, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
