### PR TITLE
Fix FuturesTest's wall-clock timing assumptions

### DIFF
--- a/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
+++ b/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
@@ -6,6 +6,7 @@
 
 import futures.*
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import io.kotest.matchers.ranges.beIn
 import io.kotest.matchers.shouldBe
@@ -259,13 +260,28 @@ class FuturesTest {
         newMyRecord("foo", 42u) shouldBe MyRecord("foo", 42u)
     }
 
+    // What this guards is that a waker firing a second time does not corrupt the
+    // future it belongs to, or let a later future complete early.
+    //
+    // Only lower bounds are asserted. An upper bound on the total would also be
+    // measuring per-await timer and FFI overhead, which on a shared CI runner is
+    // large enough to rival the sleeps themselves, and a future that never
+    // completes is already caught by runTest's own timeout.
     @Test
-    fun testBrokenSleep() = assertApproximateTime(500) {
-        brokenSleep(100U, 0U) // calls the waker twice immediately
-        sleep(100U) // wait for possible failure
+    fun testBrokenSleep() = runTest {
+        // Calls the waker a second time immediately.
+        measureTime { brokenSleep(100U, 0U) }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
+        // The stray wake must not have completed this one early.
+        measureTime { sleep(100U) shouldBe true }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
 
-        brokenSleep(100U, 100U) // calls the waker a second time after 1s
-        sleep(200U) // wait for possible failure
+        // Calls the waker a second time 100 ms later, so it lands while the
+        // following sleep is still in flight.
+        measureTime { brokenSleep(100U, 100U) }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
+        measureTime { sleep(200U) shouldBe true }
+            .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 195L
     }
 
     @Test

--- a/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
+++ b/tests/uniffi/futures/src/commonTest/kotlin/FuturesTest.kt
@@ -13,10 +13,12 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFails
@@ -284,14 +286,20 @@ class FuturesTest {
             .inWholeMilliseconds shouldBeGreaterThanOrEqualTo 195L
     }
 
+    // Cancelling the first task must let the second one acquire the resource. As above,
+    // the detector is useSharedResource throwing AsyncError.Timeout against its own
+    // 1000 ms budget, so there is no wall-clock bound here either.
     @Test
-    fun testFutureWithLockAndCancelled() = assertMaxTime(100) {
+    fun testFutureWithLockAndCancelled() = runTest {
         val job = launch {
             useSharedResource(SharedResourceOptions(releaseAfterMs = 5000U, timeoutMs = 100U))
         }
 
-        // Wait some time to ensure the task has locked the shared resource
-        delay(50)
+        // Wait some time to ensure the task has locked the shared resource. This has to
+        // leave the test scheduler: on its own, delay() runs on runTest's virtual clock
+        // and returns in about 3 ms, so the job got cancelled before it ever took the
+        // lock and the test was not exercising what it describes.
+        withContext(Dispatchers.Default) { delay(50) }
         // Cancel the job before the shared resource has been released.
         job.cancel()
 
@@ -300,9 +308,16 @@ class FuturesTest {
         useSharedResource(SharedResourceOptions(releaseAfterMs = 0U, timeoutMs = 1000U))
     }
 
+    // The first call holds the shared resource for 100 ms, and the second must still be
+    // able to take it afterwards. A resource that never gets released shows up as
+    // useSharedResource throwing AsyncError.Timeout against its own 1000 ms budget, so
+    // that is what actually detects the failure here and only the lower bound is worth
+    // asserting on the clock.
     @Test
-    fun testFutureWithLockButNotCancelled() = assertApproximateTime(100) {
-        useSharedResource(SharedResourceOptions(releaseAfterMs = 100U, timeoutMs = 1000U))
+    fun testFutureWithLockButNotCancelled() = runTest {
+        measureTime {
+            useSharedResource(SharedResourceOptions(releaseAfterMs = 100U, timeoutMs = 1000U))
+        }.inWholeMilliseconds shouldBeGreaterThanOrEqualTo 95L
         useSharedResource(SharedResourceOptions(releaseAfterMs = 0U, timeoutMs = 1000U))
     }
 }


### PR DESCRIPTION
`FuturesTest` asserts on wall-clock time in ways that break on shared runners. `testBrokenSleep` is already failing on macOS; the other two changes here are the same problem caught before it lands.

## testBrokenSleep

The test slept a nominal 500 ms across four awaits and required the total to land in [500, 1000]. On the macOS runners it came in at **1001 ms and 1008 ms**, failing by 1 ms and 8 ms. It has been failing since at least 2026-07-22, on `main` as well as on pull requests.

The overhead is structural rather than contention. Each awaited Rust timer spawns a thread and resumes back through the FFI, which costs about 5 ms locally and roughly 125 ms per await on a shared macOS runner. `testSleepWithRepeat` shows the same effect independently in the same job: 65 sequential 20 ms sleeps, nominal 1.3 s, actual 6.9 s. Raising the cap only moves the cliff, since that cost has no upper bound on a shared VM.

What the test is for is that a waker firing a second time does not corrupt its own future or let a later one finish early. That is a lower bound, and lower bounds do not care how loaded the machine is: `thread::sleep` is an at-least guarantee and `measureTime` is monotonic. So each step now asserts it took at least as long as it slept, and the upper bound is gone. A future that never completes is still caught by `runTest`'s own timeout.

These bounds are weaker than ones the file already relies on. `assertApproximateTime` asserts an exact nominal lower bound with no slack on eight other tests, across these same platforms.

## testFutureWithLockButNotCancelled

Next in line to flake: nominal 100 ms, window [100, 600], and CI was already spending 488 ms of it. The upper bound was never the detector. `use_shared_resource` returns `Result<(), AsyncError>` and throws `AsyncError.Timeout` against its own 1000 ms budget if the resource is not released, so the exception is what catches a real fault. Same treatment: keep the lower bound, drop the window.

## testFutureWithLockAndCancelled

A different problem in the same file. The test launches a job, waits for it to take the lock, then cancels it. That wait was a plain `delay(50)` inside `runTest`, which runs on the virtual clock and returns in about 3 ms, measured. The job was being cancelled before it ever took the lock, so the test had not been exercising the case it describes. Moving the wait onto `Dispatchers.Default` makes it real, which took the test from 1-15 ms to 68 ms.

Its wall-clock cap is removed rather than widened, for the same reason as its sibling: an unreleased lock surfaces as `AsyncError.Timeout` from the second acquire, and any cap large enough to be safe today is still a cliff on a runner that spent 388 ms of overhead on a single call in this very file.

## Testing

All three pass locally on `jvmTest` and `macosArm64Test`, and `uniffi-tests-gir, macos` passes on CI. Each was also checked in the failing direction: shortening a sleep to simulate a future completing early trips the new lower bound, and releasing the shared resource immediately trips the other one. The old `testBrokenSleep` measured 523 ms locally unloaded and 524 ms under 96 spinners on 12 cores, which is why this reproduces on CI runners and not on a laptop.

## What this gives up

A future that completes late but eventually, say after five seconds, is now caught by `runTest`'s 60 s timeout rather than by a 1000 ms cap. That trade is deliberate.

---

Written with AI assistance (Claude Code) and pending human review, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
